### PR TITLE
Propose algorithms if an invalid algo is requested

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -18,6 +18,7 @@ dependencies:
   - scipy=1.2.1
   - conda-verify
   - jupyter
+  - fuzzywuzzy
   - pip:
     - doc8
     - pre-commit

--- a/estimagic/optimization/optimize.py
+++ b/estimagic/optimization/optimize.py
@@ -16,6 +16,7 @@ from estimagic.optimization.process_constraints import process_constraints
 from estimagic.optimization.reparametrize import reparametrize_from_internal
 from estimagic.optimization.reparametrize import reparametrize_to_internal
 from estimagic.optimization.utilities import index_element_to_string
+from estimagic.optimization.utilities import propose_algorithms
 
 QueueEntry = namedtuple("QueueEntry", ["params", "fitness", "still_running"])
 
@@ -257,9 +258,15 @@ def _minimize(
         algos = json.load(j)
     origin, algo_name = algorithm.split("_", 1)
 
-    assert algo_name in algos[origin], "Invalid algorithm requested: {}".format(
-        algorithm
-    )
+    try:
+        assert algo_name in algos[origin], "Invalid algorithm requested: {}".format(
+            algorithm
+        )
+    except (AssertionError, KeyError):
+        proposals = propose_algorithms(algorithm, algos)
+        raise NotImplementedError(
+            f"{algorithm} is not a valid choice. Did you mean one of {proposals}?"
+        )
 
     if origin in ["nlopt", "pygmo"]:
         prob = _create_problem(internal_criterion, internal_params)

--- a/estimagic/optimization/utilities.py
+++ b/estimagic/optimization/utilities.py
@@ -61,17 +61,14 @@ def cov_matrix_to_sdcorr_params(cov):
 def number_of_triangular_elements_to_dimension(num):
     """Calculate the dimension of a square matrix from number of triangular elements.
 
-    Parameters
-    ----------
-    num : int
-        The number of upper or lower triangular elements in the matrix.
+    Args:
+        num (int): The number of upper or lower triangular elements in the matrix.
 
-    Example
-    -------
-    >>> number_of_triangular_elements_to_dimension(6)
-    3
-    >>> number_of_triangular_elements_to_dimension(10)
-    4
+    Examples:
+        >>> number_of_triangular_elements_to_dimension(6)
+        3
+        >>> number_of_triangular_elements_to_dimension(10)
+        4
 
     """
     return int(np.sqrt(8 * num + 1) / 2 - 0.5)
@@ -97,6 +94,25 @@ def index_element_to_string(element, separator="_"):
 
 
 def propose_algorithms(requested_algo, algos, number=3):
+    """Propose a a number of algorithms based on similarity to the requested algorithm.
+
+    Args:
+        requested_algo (str): From the user requested algorithm.
+        algos (dict(str, list(str))): Dictionary where keys are the package and values
+            are lists of algorithms.
+        number (int) : Number of proposals.
+
+    Returns:
+        proposals (list(str)): List of proposed algorithms.
+
+    Example:
+        >>> algos = {"scipy": ["L-BFGS-B", "TNC"], "nlopt": ["lbfgsb"]}
+        >>> propose_algorithms("scipy_L-BFGS-B", algos, number=1)
+        ['scipy_L-BFGS-B']
+        >>> propose_algorithms("L-BFGS-B", algos, number=2)
+        ['scipy_L-BFGS-B', 'nlopt_lbfgsb']
+
+    """
     possibilities = [
         "_".join([origin, algo_name]) for origin in algos for algo_name in algos[origin]
     ]

--- a/estimagic/optimization/utilities.py
+++ b/estimagic/optimization/utilities.py
@@ -1,4 +1,5 @@
 import numpy as np
+from fuzzywuzzy import process as fw_process
 
 
 def cov_params_to_matrix(cov_params):
@@ -93,3 +94,13 @@ def index_element_to_string(element, separator="_"):
     else:
         res_string = str(element)
     return res_string
+
+
+def propose_algorithms(requested_algo, algos, number=3):
+    possibilities = [
+        "_".join([origin, algo_name]) for origin in algos for algo_name in algos[origin]
+    ]
+    proposals_w_probs = fw_process.extract(requested_algo, possibilities, limit=number)
+    proposals = [proposal[0] for proposal in proposals_w_probs]
+
+    return proposals

--- a/meta.yaml
+++ b/meta.yaml
@@ -24,6 +24,7 @@ requirements:
     - bokeh>=1.1
     - scipy
     - numdifftools>= 0.9.20
+    - fuzzywuzzy
 
 test:
   commands:

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ conda_deps =
     numdifftools >= 0.9.20
     bokeh >= 1.1
     scipy >= 1.2.1
-
+    fuzzywuzzy
 conda_channels =
     defaults
     conda-forge


### PR DESCRIPTION
It might be the case that I am just to stupid as I am always confused by the names of the optimization algorithms. Thus, ``estimagic`` must help me by interpreting my request.

If I enter an invalid algorithm like ``scipy_L-BGFS-B`` (yes, it is really incorrect - you are welcome 😄), the new function ``propose_algorithms`` returns the three most likely algorithms which are shown in the error message.