### PR TITLE
Fix pickling error in multiprocessing for dashboard on Windows.

### DIFF
--- a/estimagic/dashboard/server_functions.py
+++ b/estimagic/dashboard/server_functions.py
@@ -133,5 +133,3 @@ def _setup_server(apps, port):
         # https://stackoverflow.com/a/38236630/7523785 for more information.
         server._loop.start()
         server.start()
-
-        return server

--- a/estimagic/dashboard/server_functions.py
+++ b/estimagic/dashboard/server_functions.py
@@ -54,10 +54,8 @@ def run_server(queue, stop_signal, db_options, start_param_df, start_fitness):
         )
     }
 
-    server = _setup_server(apps=apps, port=port)
-
     inner_server_process = Process(
-        target=_start_server, kwargs={"server": server}, daemon=False
+        target=_setup_server, kwargs={"apps": apps, "port": port}, daemon=False
     )
     inner_server_process.start()
 
@@ -129,9 +127,11 @@ def _setup_server(apps, port):
                 address_string, server.port, server.prefix, route
             )
             print("Bokeh app running at: " + url)
+
+        # For Windows, it is important that the server is started here as otherwise a
+        # pickling error happens within multiprocess. See
+        # https://stackoverflow.com/a/38236630/7523785 for more information.
+        server._loop.start()
+        server.start()
+
         return server
-
-
-def _start_server(server):
-    server._loop.start()
-    server.start()


### PR DESCRIPTION
The problem occurred on Windows when the dashboard is started in a new process instead of a thread.  Because of some unpickable objects, the dashboard never opens. That is because, multiprocessing on Windows is handled differently than on Linux and MacOS. On the latter, ``fork()`` is called and the fork is able to see whatever exists in the main process at call time. On Windows objects must be pickable to be transferred from the main process to the newly spawned process.

### References
- https://stackoverflow.com/a/38236630/7523785
- https://stackoverflow.com/a/9671030/7523785