### PR TITLE
Pass down algo_options for nlopt and pygmo.

### DIFF
--- a/docs/source/estimation.rst
+++ b/docs/source/estimation.rst
@@ -124,9 +124,14 @@ fixed parameters. For details see :mod:`estimagic.optimization.reparametrize`.
 List of algorithms
 ------------------
 
-.. todo:: Document the algorithms and their arguments. Provide links to the pygmo
-          documentation.
+``estimagic`` supports the following list of algorithms for optimization. To learn more
+about the options of each algorithm, follow the accompanying links.
 
+pygmo
+~~~~~
+
+The options can be found `here
+<https://esa.github.io/pagmo2/docs/python/algorithms/py_algorithms.html>`__.
 
 - pygmo_gaco
 - pygmo_de
@@ -143,6 +148,13 @@ List of algorithms
 - pygmo_xnes
 - pygmo_nsga2
 - pygmo_moead
+
+nlopt
+~~~~~
+
+The options can be found `here
+<https://nlopt.readthedocs.io/en/latest/NLopt_Python_Reference/#stopping-criteria>`__.
+
 - nlopt_cobyla
 - nlopt_bobyqa
 - nlopt_newuoa
@@ -162,6 +174,13 @@ List of algorithms
 - nlopt_var1
 - nlopt_auglag
 - nlopt_auglag_eq
+
+scipy
+~~~~~
+
+The options can be found `here
+<https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html>`__.
+
 - scipy_L-BFGS-B
 - scipy_TNC
 - scipy_SLSQP

--- a/estimagic/optimization/optimize.py
+++ b/estimagic/optimization/optimize.py
@@ -370,9 +370,11 @@ def _create_algorithm(algo_name, algo_options, origin):
     """
     if origin == "nlopt":
         algo = pg.algorithm(pg.nlopt(solver=algo_name))
+        for option, val in algo_options.items():
+            setattr(algo.extract(pg.nlopt), option, val)
     elif origin == "pygmo":
         pygmo_uda = getattr(pg, algo_name)
-        algo = pg.algorithm(pygmo_uda())
+        algo = pg.algorithm(pygmo_uda(**algo_options))
 
     return algo
 


### PR DESCRIPTION
### Description

Currently, the options are only passed for ``scipy``, but we also use ``pygmo``'s and ``nlopt``'s algorithms. They do not have the same API for that.

### Todo

- [x] Add a section in the documentation which links to the three documentations and where to find parameter values.

closes #3 