### PR TITLE
Providing a value for fixed parameters is optional.

### DIFF
--- a/docs/source/estimation.rst
+++ b/docs/source/estimation.rst
@@ -101,10 +101,10 @@ dictionary. The dictionary must contain the following entries:
       list hast to be a valid argument to ``DataFrame.loc[]`` or ``DataFrame.query()``,
       respectively. Pairwise equality constraints are just syntactic sugar and are
       converted to normal equality constraints internally.
-    - ``'fixed'``: A set of parameters is fixed to some values. In this case the
-      constraints dictionary has to contain a ``'value'`` entry which can be a scalar or
-      an iterable of suitable length.
-
+    - ``'fixed'``: A set of parameters is fixed to some values. The constraints
+      dictionary may contain a ``'value'`` entry which can be a scalar or an iterable of
+      suitable length. If ``'value'`` is not supplied, the parameters are fixed at the
+      given values.
 
 Lower and upper bounds are specified in :ref:`params`.
 

--- a/estimagic/optimization/process_constraints.py
+++ b/estimagic/optimization/process_constraints.py
@@ -303,5 +303,12 @@ def apply_fixes_to_external_params(params, fixes):
             fix["type"]
         )
         params.loc[fix["index"], "_fixed"] = True
-        params.loc[fix["index"], "value"] = fix["value"]
+        if "value" not in fix:
+            warnings.warn(
+                "No value(s) in constraints to fix parameter(s) under "
+                f"{fix['index'].values}. Fix at given value(s) instead.",
+                category=UserWarning,
+            )
+        else:
+            params.loc[fix["index"], "value"] = fix["value"]
     return params

--- a/estimagic/optimization/process_constraints.py
+++ b/estimagic/optimization/process_constraints.py
@@ -303,12 +303,6 @@ def apply_fixes_to_external_params(params, fixes):
             fix["type"]
         )
         params.loc[fix["index"], "_fixed"] = True
-        if "value" not in fix:
-            warnings.warn(
-                "No value(s) in constraints to fix parameter(s) under "
-                f"{fix['index'].values}. Fix at given value(s) instead.",
-                category=UserWarning,
-            )
-        else:
+        if "value" in fix:
             params.loc[fix["index"], "value"] = fix["value"]
     return params


### PR DESCRIPTION
Providing a value if one wants to fix a parameter should be optional, because most of the time the fixed value is identical to the one in ``params``. This leads to unnecessary duplication.

To be explicit, a warning is raised if the constraint is not accompanied by a value.