### PR TITLE
Bound distance default

### DIFF
--- a/docs/source/estimation.rst
+++ b/docs/source/estimation.rst
@@ -80,8 +80,8 @@ dictionary. The dictionary must contain the following entries:
       matrices that are only positive semi-definite but not positive-definite during
       optimization you can specify an entry ``'bounds_distance' : some_float`` in the
       constraint dictionary. The variances are then restricted to be larger than that
-      number. Even very small bounds distances (e.g. 1e-20) can make the optimization
-      much more robust.
+      number. The default is set to 1e-20.
+      Even very small bounds distances (e.g. 1e-20) can make the optimization much more robust.
     - ``'sdcorr'``: the first part of a set of parameters are standard deviations, the
       second part are the lower triangle (excluding the diagonal) of a correlation
       matrix. All parameters together can be used to construct a full covariance matrix

--- a/estimagic/optimization/process_constraints.py
+++ b/estimagic/optimization/process_constraints.py
@@ -153,7 +153,7 @@ def _process_cov_constraint(constraint, params, fixed):
     value_mat = cov_params_to_matrix(params_subset["value"].to_numpy())
     fixed_mat = cov_params_to_matrix(fixed_subset["_fixed"].to_numpy()).astype(bool)
     new_constr["case"] = _determine_cov_case(value_mat, fixed_mat, params_subset)
-    new_constr["bounds_distance"] = constraint.pop("bounds_distance", 0.0)
+    new_constr["bounds_distance"] = constraint.pop("bounds_distance", 1e-20)
 
     return new_constr
 
@@ -181,7 +181,7 @@ def _process_sdcorr_constraint(constraint, params, fixed):
     fixed_lower[np.tril_indices(dim, k=-1)] = fixed_vec[dim:]
     fixed_mat = (fixed_lower + fixed_diag + fixed_lower.T).astype(bool)
     new_constr["case"] = _determine_cov_case(value_mat, fixed_mat, params_subset)
-    new_constr["bounds_distance"] = constraint.pop("bounds_distance", 0.0)
+    new_constr["bounds_distance"] = constraint.pop("bounds_distance", 1e-20)
     return new_constr
 
 

--- a/estimagic/optimization/process_constraints.py
+++ b/estimagic/optimization/process_constraints.py
@@ -153,7 +153,7 @@ def _process_cov_constraint(constraint, params, fixed):
     value_mat = cov_params_to_matrix(params_subset["value"].to_numpy())
     fixed_mat = cov_params_to_matrix(fixed_subset["_fixed"].to_numpy()).astype(bool)
     new_constr["case"] = _determine_cov_case(value_mat, fixed_mat, params_subset)
-    new_constr["bounds_distance"] = constraint.pop("bounds_distance", 1e-20)
+    new_constr["bounds_distance"] = constraint.pop("bounds_distance", 1e-5)
 
     return new_constr
 
@@ -181,7 +181,7 @@ def _process_sdcorr_constraint(constraint, params, fixed):
     fixed_lower[np.tril_indices(dim, k=-1)] = fixed_vec[dim:]
     fixed_mat = (fixed_lower + fixed_diag + fixed_lower.T).astype(bool)
     new_constr["case"] = _determine_cov_case(value_mat, fixed_mat, params_subset)
-    new_constr["bounds_distance"] = constraint.pop("bounds_distance", 1e-20)
+    new_constr["bounds_distance"] = constraint.pop("bounds_distance", 1e-5)
     return new_constr
 
 


### PR DESCRIPTION
Changing the default bound distance such that no positive semidefinite matrices are suggested by the optimizer. 
That can lead to problems with the criterium function (for example in respy). 