### PR TITLE
Add robust cholesky and tests.

### DIFF
--- a/estimagic/optimization/reparametrize.py
+++ b/estimagic/optimization/reparametrize.py
@@ -8,6 +8,7 @@ from estimagic.optimization.utilities import cov_matrix_to_params
 from estimagic.optimization.utilities import cov_matrix_to_sdcorr_params
 from estimagic.optimization.utilities import cov_params_to_matrix
 from estimagic.optimization.utilities import number_of_triangular_elements_to_dimension
+from estimagic.optimization.utilities import robust_cholesky
 from estimagic.optimization.utilities import sdcorr_params_to_matrix
 
 
@@ -164,7 +165,7 @@ def _covariance_to_internal(params_subset, case, type_, bounds_distance):
         res["lower"] = np.maximum(res["lower"], np.zeros(len(res)))
         assert (res["upper"] >= res["lower"]).all(), "Invalid upper bound for variance."
     elif case == "free":
-        chol = np.linalg.cholesky(cov)
+        chol = robust_cholesky(cov, threshold=1e-8)
         chol_coeffs = chol[np.tril_indices(dim)]
         res["value"] = chol_coeffs
 

--- a/estimagic/optimization/utilities.py
+++ b/estimagic/optimization/utilities.py
@@ -72,9 +72,7 @@ def sdcorr_params_to_matrix(sdcorr_params):
 
 def cov_matrix_to_sdcorr_params(cov):
     dim = len(cov)
-    sds = np.sqrt(np.diagonal(cov))
-    scaling_matrix = np.diag(1 / sds)
-    corr = scaling_matrix.dot(cov).dot(scaling_matrix)
+    sds, corr = cov_to_sds_and_corr(cov)
     correlations = corr[np.tril_indices(dim, k=-1)]
     return np.hstack([sds, correlations])
 

--- a/estimagic/optimization/utilities.py
+++ b/estimagic/optimization/utilities.py
@@ -1,4 +1,5 @@
 import warnings
+from collections import namedtuple
 
 import numpy as np
 from fuzzywuzzy import process as fw_process
@@ -226,3 +227,36 @@ def robust_cholesky(matrix, threshold=None, warn=True, return_info=False):
 
     res = (chol, info) if return_info else chol
     return res
+
+
+def namedtuple_from_dict(field_dict):
+    """Filled namedtuple generated from a dictionary.
+
+    Example:
+        >>> namedtuple_from_dict({'a': 1, 'b': 2})
+        NamedTuple(a=1, b=2)
+
+    """
+    return namedtuple("NamedTuple", field_dict)(**field_dict)
+
+
+def namedtuple_from_kwargs(**kwargs):
+    """Filled namedtuple generated from keyword arguments.
+
+    Example:
+        >>> namedtuple_from_kwargs(a=1, b=2)
+        NamedTuple(a=1, b=2)
+
+    """
+    return namedtuple("NamedTuple", kwargs)(**kwargs)
+
+
+def namedtuple_from_iterables(field_names, field_entries):
+    """Filled namedtuple generated from field_names and field_entries.
+
+    Example:
+        >>> namedtuple_from_iterables(field_names=['a', 'b'], field_entries=[1, 2])
+        NamedTuple(a=1, b=2)
+
+    """
+    return namedtuple("NamedTuple", field_names)(*field_entries)

--- a/estimagic/optimization/utilities.py
+++ b/estimagic/optimization/utilities.py
@@ -153,11 +153,13 @@ def robust_cholesky(matrix, threshold=None, warn=True, return_info=False):
             minus machine accuracy.
         warn (bool): If True, the user is warned about negative elements in D
         return_info (bool): If True, also return a dictionary with 'method' and
-            'sum_stabilized'. Method can take the values 'np.linalg.cholesky',
+            'diagonals'. Method can take the values 'np.linalg.cholesky',
             'LDL cholesky' and 'LDL cholesky with QR decomposition'.
-            'sum_stabilized' is the sum of entries of D between threshold and 0 and can
-            be used to construct penalty terms.
-
+            'diagonals' are the diagonal entries of D. They can be used to construct
+            penalty terms for non positive definite matrices. Note that diagonals will
+            also be returned if the standard cholesky decomposition did not fail. This
+            allows for smooth penalty terms that start before actually reaching invalid
+            matrices.
 
     Returns:
         chol (np.array): Cholesky factor of matrix
@@ -184,6 +186,7 @@ def robust_cholesky(matrix, threshold=None, warn=True, return_info=False):
     try:
         chol = np.linalg.cholesky(matrix)
         method = "np.linalg.cholesky"
+        diags = np.diagonal(chol) ** 2
     except np.linalg.LinAlgError:
         method = "LDL cholesky"
         threshold = threshold if threshold is not None else -np.finfo(float).eps
@@ -221,7 +224,7 @@ def robust_cholesky(matrix, threshold=None, warn=True, return_info=False):
             chol = r.T
             method = "LDL cholesky with QR decomposition"
 
-    info = {"method": method, "sum_stabilized": sum_stabilized}
+    info = {"method": method, "diagonals": diags}
 
     res = (chol, info) if return_info else chol
     return res

--- a/estimagic/optimization/utilities.py
+++ b/estimagic/optimization/utilities.py
@@ -35,7 +35,7 @@ def cov_matrix_to_params(cov):
 
 def sdcorr_params_to_sds_and_corr(sdcorr_params):
     dim = number_of_triangular_elements_to_dimension(len(sdcorr_params))
-    sds = sdcorr_params[:dim]
+    sds = np.array(sdcorr_params[:dim])
     corr = np.eye(dim)
     corr[np.tril_indices(dim, k=-1)] = sdcorr_params[dim:]
     corr += np.tril(corr, k=-1).T
@@ -45,6 +45,13 @@ def sdcorr_params_to_sds_and_corr(sdcorr_params):
 def sds_and_corr_to_cov(sds, corr):
     diag = np.diag(sds)
     return diag @ corr @ diag
+
+
+def cov_to_sds_and_corr(cov):
+    sds = np.sqrt(np.diagonal(cov))
+    diag = np.diag(1 / sds)
+    corr = diag @ cov @ diag
+    return sds, corr
 
 
 def sdcorr_params_to_matrix(sdcorr_params):

--- a/estimagic/tests/optimization/test_utilities.py
+++ b/estimagic/tests/optimization/test_utilities.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 from numpy.testing import assert_array_almost_equal as aaae
 
 from estimagic.optimization.utilities import cov_matrix_to_params
@@ -7,6 +8,7 @@ from estimagic.optimization.utilities import cov_params_to_matrix
 from estimagic.optimization.utilities import dimension_to_number_of_triangular_elements
 from estimagic.optimization.utilities import index_element_to_string
 from estimagic.optimization.utilities import number_of_triangular_elements_to_dimension
+from estimagic.optimization.utilities import robust_cholesky
 from estimagic.optimization.utilities import sdcorr_params_to_matrix
 
 
@@ -61,3 +63,27 @@ def test_index_element_to_string():
     expected = ["a_b_1", "bla~5~6", "bla"]
     for inp, exp in zip(inputs, expected):
         assert index_element_to_string(*inp) == exp
+
+
+def random_cov(dim, seed):
+    num_elements = int(dim * (dim + 1) / 2)
+    chol = np.zeros((dim, dim))
+    chol[np.tril_indices(dim)] = np.random.uniform(size=num_elements)
+    cov = chol @ chol.T
+    zero_positions = np.random.choice(range(dim), size=int(dim / 5), replace=False)
+    for pos in zero_positions:
+        cov[:, pos] = 0
+        cov[pos] = 0
+    return cov
+
+
+seeds = [58822, 3181, 98855, 44002, 47631, 97741, 10655, 4600, 1151, 58189]
+dims = [8] * 6 + [10, 12, 15, 20]
+
+
+@pytest.mark.parametrize("dim, seed", zip(dims, seeds))
+def test_robust_cholesky(dim, seed):
+    cov = random_cov(dim, seed)
+    chol = robust_cholesky(cov)
+    aaae(chol.dot(chol.T), cov)
+    assert (chol[np.triu_indices(len(cov), k=1)] == 0).all()

--- a/estimagic/tests/optimization/test_utilities.py
+++ b/estimagic/tests/optimization/test_utilities.py
@@ -82,8 +82,14 @@ dims = [8] * 6 + [10, 12, 15, 20]
 
 
 @pytest.mark.parametrize("dim, seed", zip(dims, seeds))
-def test_robust_cholesky(dim, seed):
+def test_robust_cholesky_with_zero_variance(dim, seed):
     cov = random_cov(dim, seed)
     chol = robust_cholesky(cov)
     aaae(chol.dot(chol.T), cov)
     assert (chol[np.triu_indices(len(cov), k=1)] == 0).all()
+
+
+def test_robust_cholesky_with_extreme_cases():
+    for cov in [np.ones((5, 5)), np.zeros((5, 5))]:
+        chol = robust_cholesky(cov)
+        aaae(chol.dot(chol.T), cov)

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages
 from setuptools import setup
 
-version = "0.0.13"
+version = "0.0.14"
 
 setup(
     name="estimagic",


### PR DESCRIPTION
closes #67 

Add a robust cholesky decomposition that works for semi-definite covariance matrices

Tasks

- [x] write robust_cholesky
- [x] add tests
- [x] use robust_cholesky in reparametrize
- [x] replace dot product with d by column scaling

In the process I added a few more functions to `estimagic.optimization.utilities` and made the code prettier. 