### PR TITLE
Logging

### DIFF
--- a/estimagic/optimization/optimize.py
+++ b/estimagic/optimization/optimize.py
@@ -1,5 +1,6 @@
 """Functional wrapper around the pygmo, nlopt and scipy libraries."""
 import json
+import sqlite3
 from collections import namedtuple
 from multiprocessing import Event
 from multiprocessing import Process
@@ -7,6 +8,7 @@ from multiprocessing import Queue
 from pathlib import Path
 
 import numpy as np
+import pandas as pd
 import pygmo as pg
 from scipy.optimize import minimize as scipy_minimize
 
@@ -432,7 +434,7 @@ def _logging(params, fitness_eval, counter, log_interval=100, path_to_sql="loggi
         counter (int): number of current iteration
         log_interval (int): number of iterations until first logging shall
                             occur
-        path_to_sql: path to sql database
+        path_to_sql (str): path to sql database (needs to end with .db)
 
     """
     if counter % log_interval == 0:
@@ -446,14 +448,8 @@ def _logging(params, fitness_eval, counter, log_interval=100, path_to_sql="loggi
         p_final["fitness_eval"] = fitness_eval
         p_final["iteration"] = counter
 
-
         # Save results as sql database
         conn = sqlite3.connect(path_to_sql)
-        p_final.to_sql(
-                name="params",
-                con=conn,
-                if_exists="append",
-                index=False,
-        )
+        p_final.to_sql(name="params", con=conn, if_exists="append", index=False)
         conn.commit()
         conn.close()


### PR DESCRIPTION
Four comments:

1. logging function requires two additional arguments: 

     - log_interval (at which iteration to save results at, default right now, every 100th iteration)
     - path_to_sql: where the to save the database to, default right now "logging.db"

2. The Transposing of the parameter DataFrame may be a little inefficient, but I could not find a more straightforward way because of the multiindex,  suggestions very welcome.

3. Right now builds on sqlite3, but pandas also supports sqlalchemy and only keeps sqlite3 for "legacy" reasons. I find sqlite3 much more straightforward than sqlalchemy. In my opinion, sqlalchemy is alittle overkill for a small problem like this one. Nevertheless, if you prefer sqlalchemy, it should be easy enough to change it.

4. Upon restarting optimization, would append the results to the old results, if this is not the behavior that you would like to have, this should be easy enough to change.