### PR TITLE
Fixed values should appear in estimation output.

### DIFF
--- a/estimagic/optimization/reparametrize.py
+++ b/estimagic/optimization/reparametrize.py
@@ -109,6 +109,8 @@ def reparametrize_from_internal(internal_params, constraints, original_params):
             external.update(_probability_from_internal(params_subset))
         elif constr["type"] == "increasing":
             external.update(_increasing_from_internal(params_subset))
+        elif constr["type"] == "fixed":
+            external.update(_fixed_from_internal(params_subset, constr))
         elif constr["type"] in ["fixed", "equality"]:
             pass
         else:
@@ -408,4 +410,17 @@ def _equality_from_internal(params_subset):
     first = params_subset.index[0]
     all_others = params_subset.index[1:]
     res.loc[all_others, "value"] = res.loc[first, "value"]
+    return res["value"]
+
+
+def _fixed_from_internal(params_subset, constr):
+    """Reparametrize fixed parameters from internal.
+
+    Overwrite fixed parameters
+
+    """
+    res = params_subset.copy()
+    value = constr.get("value", None)
+    if value is not None:
+        res["value"] = value
     return res["value"]

--- a/estimagic/optimization/reparametrize.py
+++ b/estimagic/optimization/reparametrize.py
@@ -414,11 +414,7 @@ def _equality_from_internal(params_subset):
 
 
 def _fixed_from_internal(params_subset, constr):
-    """Reparametrize fixed parameters from internal.
-
-    Overwrite fixed parameters
-
-    """
+    """Overwrite fixed parameters with the value in the constraints if provided."""
     res = params_subset.copy()
     value = constr.get("value", None)
     if value is not None:

--- a/estimagic/optimization/reparametrize.py
+++ b/estimagic/optimization/reparametrize.py
@@ -111,7 +111,7 @@ def reparametrize_from_internal(internal_params, constraints, original_params):
             external.update(_increasing_from_internal(params_subset))
         elif constr["type"] == "fixed":
             external.update(_fixed_from_internal(params_subset, constr))
-        elif constr["type"] in ["fixed", "equality"]:
+        elif constr["type"] == "equality":
             pass
         else:
             raise ValueError("Invalid constraint type: {}".format(constr["type"]))


### PR DESCRIPTION
If you fix a parameter and there is already a different value in ``params``, the estimation output does not return the fixed value, but the original entry.