### PR TITLE
Correct the documentation on pairwise equality constraints.

### DIFF
--- a/docs/source/optimization/constraints.ipynb
+++ b/docs/source/optimization/constraints.ipynb
@@ -995,27 +995,23 @@
    "source": [
     "## pairwise_equality constraints\n",
     "\n",
-    "Pairwise equality constraints are different from all other constraints because correspond to two sets of parameters. Let's assume we want to keep the parameters \"a\" and \"b\" pairwise equal, then the constraint looks like this:"
+    "Pairwise equality constraints are different from all other constraints because correspond to several sets of parameters. Let's assume we want to keep the parameters \"a\" and \"b\" pairwise equal, then the constraint looks like this:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 84,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
-    "constr = {\"loc1\": \"a\", \"loc2\": \"b\", \"type\": \"pairwise_equality\"}"
+    "constr = {\"locs\": [\"a\", \"b\"], \"type\": \"pairwise_equality\"}"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You can use any of the following combinations to select parameters:\n",
-    "- \"loc1\", \"loc2\"\n",
-    "- \"loc1\", \"query2\",\n",
-    "- \"query1\", \"loc2\",\n",
-    "- \"query1\", \"query2\""
+    "Alternatively, you could have an entry \"queries\" where the corresponding value is a list if query strings. Both \"locs\" and \"queries\" can have any number of entries. "
    ]
   },
   {

--- a/docs/source/optimization/constraints.ipynb
+++ b/docs/source/optimization/constraints.ipynb
@@ -995,7 +995,7 @@
    "source": [
     "## pairwise_equality constraints\n",
     "\n",
-    "Pairwise equality constraints are different from all other constraints because correspond to several sets of parameters. Let's assume we want to keep the parameters \"a\" and \"b\" pairwise equal, then the constraint looks like this:"
+    "Pairwise equality constraints are different from all other constraints because they correspond to several sets of parameters. Let's assume we want to keep the parameters \"a\" and \"b\" pairwise equal, then the constraint looks like this:"
    ]
   },
   {

--- a/estimagic/optimization/process_constraints.py
+++ b/estimagic/optimization/process_constraints.py
@@ -124,7 +124,7 @@ def _process_selectors(constraints, params):
         if constr["type"] == "pairwise_equality":
             assert (
                 len(indices) >= 2
-            ), "Select at least two 2 of parameters for pairwise equality constraint!"
+            ), "Select at least 2 sets of parameters for pairwise equality constraint!"
             length = len(indices[0])
             for index in indices:
                 assert (


### PR DESCRIPTION
When I used pairwise equality constraints in skillmodels, I realized that the implementation is much smarter than I had thought and documented. 