### PR TITLE
Make the constraints NB more readable.

### DIFF
--- a/docs/source/optimization/constraints.ipynb
+++ b/docs/source/optimization/constraints.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -38,7 +38,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -48,10 +48,357 @@
     ")\n",
     "\n",
     "df = pd.DataFrame(\n",
-    "    data=list(\"abcdef\"), \n",
+    "    data=[0.1, 0.45, 0.55, 0.75, 0.85, -1.0], \n",
     "    index=index,\n",
-    "    columns=[\"bla\"],\n",
+    "    columns=[\"value\"],\n",
     ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th>value</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>category</th>\n",
+       "      <th>number</th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <td rowspan=\"3\" valign=\"top\">a</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0.10</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>1</td>\n",
+       "      <td>0.45</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>2</td>\n",
+       "      <td>0.55</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td rowspan=\"3\" valign=\"top\">b</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0.75</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>1</td>\n",
+       "      <td>0.85</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>2</td>\n",
+       "      <td>-1.00</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                 value\n",
+       "category number       \n",
+       "a        0        0.10\n",
+       "         1        0.45\n",
+       "         2        0.55\n",
+       "b        0        0.75\n",
+       "         1        0.85\n",
+       "         2       -1.00"
+      ]
+     },
+     "execution_count": 29,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To select subsets of the rows we have two options: [loc](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.loc.html) and [query](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.query.html). \n",
+    "\n",
+    "``loc`` is best if the rows we want to select correspond to an entry in the index, reading from the left. For example, we can select all parameters of category \"a\" by:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>value</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>number</th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <td>0</td>\n",
+       "      <td>0.10</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>1</td>\n",
+       "      <td>0.45</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>2</td>\n",
+       "      <td>0.55</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "        value\n",
+       "number       \n",
+       "0        0.10\n",
+       "1        0.45\n",
+       "2        0.55"
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.loc[\"a\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In order to only get the second row, we would do:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "value    0.45\n",
+       "Name: (a, 1), dtype: float64"
+      ]
+     },
+     "execution_count": 31,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.loc[(\"a\", 1)]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For these examples, ``query`` would be much more verbose:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th>value</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>category</th>\n",
+       "      <th>number</th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <td rowspan=\"3\" valign=\"top\">a</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0.10</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>1</td>\n",
+       "      <td>0.45</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>2</td>\n",
+       "      <td>0.55</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                 value\n",
+       "category number       \n",
+       "a        0        0.10\n",
+       "         1        0.45\n",
+       "         2        0.55"
+      ]
+     },
+     "execution_count": 32,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.query(\"category == 'a'\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "However, if we wanted to select all columns where number equals 1, loc would be more cumbersome:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th>value</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>category</th>\n",
+       "      <th>number</th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <td>a</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0.45</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>b</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0.85</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                 value\n",
+       "category number       \n",
+       "a        1        0.45\n",
+       "b        1        0.85"
+      ]
+     },
+     "execution_count": 33,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.loc[[(\"a\", 1), (\"b\", 1)]]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Imagine how that would look like if we had twenty categories! For such more cases, query is a much better solution:"
    ]
   },
   {
@@ -81,7 +428,7 @@
        "    <tr style=\"text-align: right;\">\n",
        "      <th></th>\n",
        "      <th></th>\n",
-       "      <th>bla</th>\n",
+       "      <th>value</th>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>category</th>\n",
@@ -91,44 +438,24 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th rowspan=\"3\" valign=\"top\">a</th>\n",
-       "      <th>0</th>\n",
        "      <td>a</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0.45</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>1</th>\n",
        "      <td>b</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>c</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th rowspan=\"3\" valign=\"top\">b</th>\n",
-       "      <th>0</th>\n",
-       "      <td>d</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>e</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>f</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0.85</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "                bla\n",
-       "category number    \n",
-       "a        0        a\n",
-       "         1        b\n",
-       "         2        c\n",
-       "b        0        d\n",
-       "         1        e\n",
-       "         2        f"
+       "                 value\n",
+       "category number       \n",
+       "a        1        0.45\n",
+       "b        1        0.85"
       ]
      },
      "execution_count": 34,
@@ -137,225 +464,21 @@
     }
    ],
    "source": [
-    "df"
+    "df.query(\"number == 1\")"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To select subsets of the rows we have two options: ``loc`` and ``query``. ``loc`` is best if the rows we want to select correspond to an entry in the index. For example, we can select all parameters of category \"a\" by:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 35,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>bla</th>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>number</th>\n",
-       "      <th></th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>a</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>b</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>c</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "       bla\n",
-       "number    \n",
-       "0        a\n",
-       "1        b\n",
-       "2        c"
-      ]
-     },
-     "execution_count": 35,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "df.loc[\"a\"]"
+    "In order to specify constraints for a parameter, you specify either ``loc`` or ``query``, this will be passed on as an argument to `params_df.loc[]` or `params_df.query()`, respectively."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If instead we wanted to select the first two entries of category \"b\", loc would be more cumbersome:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 36,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th>bla</th>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>category</th>\n",
-       "      <th>number</th>\n",
-       "      <th></th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th rowspan=\"2\" valign=\"top\">b</th>\n",
-       "      <th>0</th>\n",
-       "      <td>d</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>e</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                bla\n",
-       "category number    \n",
-       "b        0        d\n",
-       "         1        e"
-      ]
-     },
-     "execution_count": 36,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "df.loc[[(\"b\", 0), (\"b\", 1)]]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "For such more cases, query can be a better solution:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 37,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th>bla</th>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>category</th>\n",
-       "      <th>number</th>\n",
-       "      <th></th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th rowspan=\"2\" valign=\"top\">a</th>\n",
-       "      <th>0</th>\n",
-       "      <td>a</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>b</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                bla\n",
-       "category number    \n",
-       "a        0        a\n",
-       "         1        b"
-      ]
-     },
-     "execution_count": 37,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "df.query(\"category == 'a' & number <= 1\")"
+    "Note that the value ist optional here. If you don't specify it, estimagic will fix the parameter at the start value. "
    ]
   },
   {
@@ -379,9 +502,237 @@
     "    - \"fixed\"\n",
     "    \n",
     "   \n",
-    "Depending on the type of constraint there might be additional values. Each type of constraint is described in more detail below.\n",
+    "Depending on the type of constraint there might be additional values. Each type of constraint is described in more detail below.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## fixed constraints\n",
     "\n",
+    "To diagnose what goes wrong in difficult optimizations you often want to fix some of the parameters. Of course, you could just remove them from your parameter vector, but again, it's very handy if the parameter vector that arrives in your utility function always looks exactly the same. Therefore, estimagic can fix the parameters for you. A good example of a parameter that is fixed is a discount factor in a structural model. In the robinson example from above, this looks like this:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "constr = {\"loc\": \"delta\", \"type\": \"fixed\", \"value\": 0.95}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## sum constraints\n",
     "\n",
+    "\"sum\" constraints ensure that the selected parameters sum to a certain value. Assume we have a group of parameters whose first index level is \"betas\" and for some reason the betas have to sum to one. Then the constraint would look as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "constr = {\"loc\": \"betas\", \"type\": \"sum\", \"value\": 5}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The \"value\" is mandatory in sum constraints and sum constraints are currently not compatible with other constraints on the same parameters.  "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## probability constraints\n",
+    "\n",
+    "Probability constraints are similar to sum constraints, but they always sum to 1 and there is the additional constraint that they are all between zero and one. Probability constraints are therefore also pratical for shares or parameters of certain production functions. Let's assume we have a params DataFrame with \"shares\" in the fist index level. As you probably guess by now, the constraint will look as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "constr = {\"loc\": \"shares\", \"type\": \"probability\"}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## increasing constraints\n",
+    "\n",
+    "As the name suggests, increasing constraints ensure that the selected parameters are increasing. The prime example are cutoffs in ordered choice models as for example the ordered logit model [Ordered Logit Example](../getting_started/ordered_logit_example.ipynb)\n",
+    "\n",
+    "The constraint then looks as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "constr = {\"loc\": \"cutoffs\", \"type\": \"increasing\"}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## equality constraints\n",
+    "\n",
+    "Equality constraints ensure that all selected parameters are equal. This sounds useless because one could simply leave all but one parameters out. But it does very often make the parsing of the parameter vector much easier. For example in dynamic models where you sometimes want to keep parameters time-invariant and sometimes not. The code often becomes much easier if you do not need if-conditions to handle those two (or potentially many more) cases and instead let estimagic handle them for you. An example could be the simple DataFrame from the very beginning, where \"a\" could be the name of a parameter and \"number\" could enumerate periods in the model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th>value</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>category</th>\n",
+       "      <th>number</th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <td rowspan=\"3\" valign=\"top\">a</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0.10</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>1</td>\n",
+       "      <td>0.45</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>2</td>\n",
+       "      <td>0.55</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td rowspan=\"3\" valign=\"top\">b</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0.75</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>1</td>\n",
+       "      <td>0.85</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>2</td>\n",
+       "      <td>-1.00</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                 value\n",
+       "category number       \n",
+       "a        0        0.10\n",
+       "         1        0.45\n",
+       "         2        0.55\n",
+       "b        0        0.75\n",
+       "         1        0.85\n",
+       "         2       -1.00"
+      ]
+     },
+     "execution_count": 39,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Keep parameter \"b\" time-invariant would be as simple as:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "constr = {\"loc\": \"b\", \"type\": \"equality\"}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This would fix all values of \"b\" at **XXXX**. However, estimagic will give you a warning because it is good practice to make sure the constrains are satisfied in the start values vector, even if they are disregarded. In this case, it would amount to setting all values for \"b\" to **XXXX**."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## pairwise_equality constraints\n",
+    "\n",
+    "Pairwise equality constraints are different from all other constraints because they correspond to several sets of parameters. Let's assume we want to keep the parameters \"a\" and \"b\" pairwise equal, then the constraint looks like this:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "constr = {\"locs\": [\"a\", \"b\"], \"type\": \"pairwise_equality\"}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Alternatively, you could have an entry \"queries\" where the corresponding value is a list of query strings. Both \"locs\" and \"queries\" can have any number of entries. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Covariance Constraints\n",
     "\n",
     "In maximum likelihood estimations, you often have to estimate a covariance matrix of a contribution. \n",
@@ -393,7 +744,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 71,
+   "execution_count": 42,
    "metadata": {},
    "outputs": [
     {
@@ -428,75 +779,75 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>delta</th>\n",
-       "      <th>delta</th>\n",
+       "      <td>delta</td>\n",
+       "      <td>delta</td>\n",
        "      <td>0.950000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th rowspan=\"2\" valign=\"top\">wage_fishing</th>\n",
-       "      <th>exp_fishing</th>\n",
+       "      <td rowspan=\"2\" valign=\"top\">wage_fishing</td>\n",
+       "      <td>exp_fishing</td>\n",
        "      <td>0.100000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>contemplation_with_friday</th>\n",
+       "      <td>contemplation_with_friday</td>\n",
        "      <td>0.400000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>nonpec_fishing</th>\n",
-       "      <th>constant</th>\n",
+       "      <td>nonpec_fishing</td>\n",
+       "      <td>constant</td>\n",
        "      <td>-1.000000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th rowspan=\"2\" valign=\"top\">nonpec_friday</th>\n",
-       "      <th>constant</th>\n",
+       "      <td rowspan=\"2\" valign=\"top\">nonpec_friday</td>\n",
+       "      <td>constant</td>\n",
        "      <td>-1.000000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>not_fishing_last_period</th>\n",
+       "      <td>not_fishing_last_period</td>\n",
        "      <td>-1.000000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th rowspan=\"2\" valign=\"top\">nonpec_hammock</th>\n",
-       "      <th>constant</th>\n",
+       "      <td rowspan=\"2\" valign=\"top\">nonpec_hammock</td>\n",
+       "      <td>constant</td>\n",
        "      <td>2.500000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>not_fishing_last_period</th>\n",
+       "      <td>not_fishing_last_period</td>\n",
        "      <td>-1.000000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th rowspan=\"6\" valign=\"top\">shocks_cov</th>\n",
-       "      <th>var_fishing</th>\n",
+       "      <td rowspan=\"6\" valign=\"top\">shocks_cov</td>\n",
+       "      <td>var_fishing</td>\n",
        "      <td>1.000000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>cov_friday_fishing</th>\n",
+       "      <td>cov_friday_fishing</td>\n",
        "      <td>0.000000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>var_friday</th>\n",
+       "      <td>var_friday</td>\n",
        "      <td>1.000000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>cov_hammock_fishing</th>\n",
+       "      <td>cov_hammock_fishing</td>\n",
        "      <td>-0.200000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>cov_hammock_friday</th>\n",
+       "      <td>cov_hammock_friday</td>\n",
        "      <td>0.000000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>var_hammock</th>\n",
+       "      <td>var_hammock</td>\n",
        "      <td>1.000000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>lagged_choice_1_hammock</th>\n",
-       "      <th>constant</th>\n",
+       "      <td>lagged_choice_1_hammock</td>\n",
+       "      <td>constant</td>\n",
        "      <td>1.000000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>meas_error</th>\n",
-       "      <th>sd_fishing</th>\n",
+       "      <td>meas_error</td>\n",
+       "      <td>sd_fishing</td>\n",
        "      <td>0.000001</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
@@ -524,7 +875,7 @@
        "meas_error              sd_fishing                 0.000001"
       ]
      },
-     "execution_count": 71,
+     "execution_count": 42,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -543,7 +894,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 72,
+   "execution_count": 43,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -559,7 +910,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 73,
+   "execution_count": 44,
    "metadata": {},
    "outputs": [
     {
@@ -570,13 +921,14 @@
        "       [-0.2,  0. ,  1. ]])"
       ]
      },
-     "execution_count": 73,
+     "execution_count": 44,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "from estimagic.optimization.utilities import cov_params_to_matrix\n",
+    "\n",
     "cov_params_to_matrix(params.loc[\"shocks_cov\", \"value\"])"
    ]
   },
@@ -606,7 +958,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 74,
+   "execution_count": 45,
    "metadata": {},
    "outputs": [
     {
@@ -641,75 +993,75 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>delta</th>\n",
-       "      <th>delta</th>\n",
+       "      <td>delta</td>\n",
+       "      <td>delta</td>\n",
        "      <td>0.950000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th rowspan=\"2\" valign=\"top\">wage_fishing</th>\n",
-       "      <th>exp_fishing</th>\n",
+       "      <td rowspan=\"2\" valign=\"top\">wage_fishing</td>\n",
+       "      <td>exp_fishing</td>\n",
        "      <td>0.100000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>contemplation_with_friday</th>\n",
+       "      <td>contemplation_with_friday</td>\n",
        "      <td>0.400000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>nonpec_fishing</th>\n",
-       "      <th>constant</th>\n",
+       "      <td>nonpec_fishing</td>\n",
+       "      <td>constant</td>\n",
        "      <td>-1.000000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th rowspan=\"2\" valign=\"top\">nonpec_friday</th>\n",
-       "      <th>constant</th>\n",
+       "      <td rowspan=\"2\" valign=\"top\">nonpec_friday</td>\n",
+       "      <td>constant</td>\n",
        "      <td>-1.000000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>not_fishing_last_period</th>\n",
+       "      <td>not_fishing_last_period</td>\n",
        "      <td>-1.000000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th rowspan=\"2\" valign=\"top\">nonpec_hammock</th>\n",
-       "      <th>constant</th>\n",
+       "      <td rowspan=\"2\" valign=\"top\">nonpec_hammock</td>\n",
+       "      <td>constant</td>\n",
        "      <td>2.500000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>not_fishing_last_period</th>\n",
+       "      <td>not_fishing_last_period</td>\n",
        "      <td>-1.000000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th rowspan=\"6\" valign=\"top\">shocks_sdcorr</th>\n",
-       "      <th>sd_fishing</th>\n",
+       "      <td rowspan=\"6\" valign=\"top\">shocks_sdcorr</td>\n",
+       "      <td>sd_fishing</td>\n",
        "      <td>1.000000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>sd_friday</th>\n",
+       "      <td>sd_friday</td>\n",
        "      <td>1.000000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>sd_hammock</th>\n",
+       "      <td>sd_hammock</td>\n",
        "      <td>1.000000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>corr_friday_fishing</th>\n",
+       "      <td>corr_friday_fishing</td>\n",
        "      <td>0.000000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>corr_hammock_fishing</th>\n",
+       "      <td>corr_hammock_fishing</td>\n",
        "      <td>-0.200000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>corr_hammock_friday</th>\n",
+       "      <td>corr_hammock_friday</td>\n",
        "      <td>0.000000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>lagged_choice_1_hammock</th>\n",
-       "      <th>constant</th>\n",
+       "      <td>lagged_choice_1_hammock</td>\n",
+       "      <td>constant</td>\n",
        "      <td>1.000000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>meas_error</th>\n",
-       "      <th>sd_fishing</th>\n",
+       "      <td>meas_error</td>\n",
+       "      <td>sd_fishing</td>\n",
        "      <td>0.000001</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
@@ -737,7 +1089,7 @@
        "meas_error              sd_fishing                 0.000001"
       ]
      },
-     "execution_count": 74,
+     "execution_count": 45,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -756,7 +1108,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 75,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -772,7 +1124,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 76,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -781,7 +1133,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 77,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
@@ -790,7 +1142,7 @@
        "array([1., 1., 1.])"
       ]
      },
-     "execution_count": 77,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -802,7 +1154,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 78,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
@@ -813,230 +1165,13 @@
        "       [-0.2,  0. ,  1. ]])"
       ]
      },
-     "execution_count": 78,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "corr"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## sum constraints\n",
-    "\n",
-    "\"sum\" constraints ensure that the selected parameters sum to a certain value. Assume we have a group of parameters whose first index level is \"betas\" and for some reason the betas have to sum to one. Then the constraint would look as follows:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 79,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "constr = {\"loc\": \"betas\", \"type\": \"sum\", \"value\": 5}"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The \"value\" is mandatory in sum constraints and sum constraints are currently not compatible with other constraints on the same parameters.  "
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## probability constraints\n",
-    "\n",
-    "Probability constraints are similar to sum constraints, but they always sum to 1 and there is the additional constraint that they are all between zero and one. Probability constraints are therefore also pratical for shares or parameters of certain production functions. Let's assume we have a params DataFrame with \"shares\" in the fist index level. As you probably guess by now, the constraint will look as follows:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 80,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "constr = {\"loc\": \"shares\", \"type\": \"probability\"}"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## increasing constraints\n",
-    "\n",
-    "As the name suggests, increasing constraints ensure that the selected parameters are increasing. The prime example are cutoffs in ordered choice models as for example the ordered logit model [Ordered Logit Example](../getting_started/ordered_logit_example.ipynb)\n",
-    "\n",
-    "The constraint then looks as follows:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 81,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "constr = {\"loc\": \"cutoffs\", \"type\": \"increasing\"}"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## equality constraints\n",
-    "\n",
-    "Equality constraints ensure that all selected parameters are equal. This sounds useless because one could simply leave all but one parameters out. But it does very often make the parsing of the parameter vector much easier. For example in dynamic models where you sometimes want to keep parameters time-invariant and sometimes not. The code ofte becomes much easier if you don't need if conditions to handle those two (or potentially many more) cases and instead let estimagic handle them for you. An example could be the simple DataFrame from the very beginning, where \"a\" could be the name of a parameter and \"number\" could enumerate periods in the model. Let's say we want to keep parameter \"b\" time-invariant."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 82,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th>bla</th>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>category</th>\n",
-       "      <th>number</th>\n",
-       "      <th></th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th rowspan=\"3\" valign=\"top\">a</th>\n",
-       "      <th>0</th>\n",
-       "      <td>a</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>b</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>c</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th rowspan=\"3\" valign=\"top\">b</th>\n",
-       "      <th>0</th>\n",
-       "      <td>d</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>e</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>f</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                bla\n",
-       "category number    \n",
-       "a        0        a\n",
-       "         1        b\n",
-       "         2        c\n",
-       "b        0        d\n",
-       "         1        e\n",
-       "         2        f"
-      ]
-     },
-     "execution_count": 82,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "df"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 83,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "constr = {\"loc\": \"b\", \"type\": \"equality\"}"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## pairwise_equality constraints\n",
-    "\n",
-    "Pairwise equality constraints are different from all other constraints because they correspond to several sets of parameters. Let's assume we want to keep the parameters \"a\" and \"b\" pairwise equal, then the constraint looks like this:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "constr = {\"locs\": [\"a\", \"b\"], \"type\": \"pairwise_equality\"}"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Alternatively, you could have an entry \"queries\" where the corresponding value is a list if query strings. Both \"locs\" and \"queries\" can have any number of entries. "
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## fixed constraints\n",
-    "\n",
-    "To diagnose what goes wrong in difficult optimizations you often want to fix some of the parameters. Of course, you could just remove them from your parameter vector, but again, it's very handy if the parameter vector that arrives in your utility function always looks exactly the same. Therefore, estimagic can fix the parameters for you. A good example of a parameter that is fixed is a discount factor in a structural model. In the robinson example from above, this looks like this:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 85,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "constr = {\"loc\": \"delta\", \"type\": \"fixed\", \"value\": 0.95}"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Note that the value ist optional here. If you don't specify it, estimagic will fix the parameter at the start value. "
    ]
   },
   {
@@ -1050,11 +1185,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 86,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [],
    "source": [
-    "constraits = [{\"loc\": \"a\", \"type\": \"equality\", \"id\": 0}, {\"loc\": \"b\", \"type\": \"increasing\", \"id\": 1}]"
+    "constraints = [\n",
+    "    {\"loc\": \"a\", \"type\": \"equality\", \"id\": 0},\n",
+    "    {\"loc\": \"b\", \"type\": \"increasing\", \"id\": 1}\n",
+    "]"
    ]
   },
   {
@@ -1066,7 +1204,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 87,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1082,7 +1220,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 89,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1103,6 +1241,13 @@
     "2. Add \"id\" entries to all constraints\n",
     "3. Give the user the possibility to look at the constraints that were constructed automatically"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -1121,9 +1266,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.6.7"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
While teaching myself, I updated the example a little (*value* instead of *bla*, numbers instead of letters in the data) and tried to be a bit more explicit here and there. 

Re-ordered the constraints s.t. the simplest one is first and the example from the top of the page and Robinson Crusoe are not mixed.

Left one case out because I did not have time to actually check what is happening. 