### PR TITLE
Adjustments Needed for Skillmodels + Bug Fixes

### DIFF
--- a/estimagic/optimization/check_constraints.py
+++ b/estimagic/optimization/check_constraints.py
@@ -16,6 +16,9 @@ def check_constraints_are_satisfied(pc, params):
     This should be called before the more specialized constraints are rewritten to
     linear constraints in order to get better error messages!
 
+    We let the checks pass if all parameter values are np.nan. This is useful for the
+    construction of star parameters.
+
     Args:
         pc (list): List of constraints with processed selectors.
         params (pd.DataFrame): See :ref:`params`
@@ -24,55 +27,58 @@ def check_constraints_are_satisfied(pc, params):
         ValueError if constraints are not satisfied.
 
     """
-    for constr in pc:
-        typ = constr["type"]
-        subset = params.iloc[constr["index"]]["value"]
-        msg = f"{{}}:\n{subset.to_frame()}"
-        if typ == "covariance":
-            cov = cov_params_to_matrix(subset)
-            e, v = np.linalg.eigh(cov)
-            if not np.all(e > -1e-8):
-                raise ValueError(msg.format("Invalid covariance parameters."))
-        elif typ == "sdcorr":
-            cov = sdcorr_params_to_matrix(subset)
-            if (subset.iloc[: len(cov)] < 0).any():
-                raise ValueError(msg.format("Invalid standard deviations."))
-            if ((subset.iloc[len(cov) :] < -1) | (subset.iloc[len(cov) :] > 1)).any():
-                raise ValueError(msg.format("Invalid correlations."))
-            e, v = np.linalg.eigh(cov)
-            if not np.all(e > -1e-8):
-                raise ValueError(msg.format("Invalid sdcorr parameters."))
-        elif typ == "probability":
-            if not np.isclose(subset.sum(), 1, rtol=0.01):
-                raise ValueError(msg.format("Probabilities do not sum to 1"))
-            if np.any(subset < 0):
-                raise ValueError(msg.format("Negative Probability."))
-            if np.any(subset > 1):
-                raise ValueError(msg.format("Probability larger than 1."))
-        elif typ == "increasing":
-            if np.any(np.diff(subset) < 0):
-                raise ValueError(msg.format("Increasing constraint violated."))
-        elif typ == "decreasing":
-            if np.any(np.diff(subset) > 0):
-                raise ValueError(msg.format("Decreasing constraint violated"))
-        elif typ == "linear":
-            # using sr.dot is important in case weights are a series in wrong order
-            wsum = subset.dot(constr["weights"])
-            if "lower" in constr and wsum < constr["lower"]:
-                raise ValueError(
-                    msg.format("Lower bound of linear constraint violated")
-                )
-            elif "upper" in constr and wsum > constr["upper"]:
-                raise ValueError(
-                    msg.format("Upper bound of linear constraint violated")
-                )
-            elif "value" in constr and not np.isclose(wsum, constr["value"]):
-                raise ValueError(
-                    msg.format("Equality condition of linear constraint violated")
-                )
-        elif typ == "equality":
-            if len(subset.unique()) != 1:
-                raise ValueError(msg.format("Equality constraint violated."))
+
+    if params["value"].notnull().any():
+        for constr in pc:
+            typ = constr["type"]
+            subset = params.iloc[constr["index"]]["value"]
+            msg = f"{{}}:\n{subset.to_frame()}"
+            if typ == "covariance":
+                cov = cov_params_to_matrix(subset)
+                e, v = np.linalg.eigh(cov)
+                if not np.all(e > -1e-8):
+                    raise ValueError(msg.format("Invalid covariance parameters."))
+            elif typ == "sdcorr":
+                cov = sdcorr_params_to_matrix(subset)
+                dim = len(cov)
+                if (subset.iloc[:dim] < 0).any():
+                    raise ValueError(msg.format("Invalid standard deviations."))
+                if ((subset.iloc[dim:] < -1) | (subset.iloc[dim:] > 1)).any():
+                    raise ValueError(msg.format("Invalid correlations."))
+                e, v = np.linalg.eigh(cov)
+                if not np.all(e > -1e-8):
+                    raise ValueError(msg.format("Invalid sdcorr parameters."))
+            elif typ == "probability":
+                if not np.isclose(subset.sum(), 1, rtol=0.01):
+                    raise ValueError(msg.format("Probabilities do not sum to 1"))
+                if np.any(subset < 0):
+                    raise ValueError(msg.format("Negative Probability."))
+                if np.any(subset > 1):
+                    raise ValueError(msg.format("Probability larger than 1."))
+            elif typ == "increasing":
+                if np.any(np.diff(subset) < 0):
+                    raise ValueError(msg.format("Increasing constraint violated."))
+            elif typ == "decreasing":
+                if np.any(np.diff(subset) > 0):
+                    raise ValueError(msg.format("Decreasing constraint violated"))
+            elif typ == "linear":
+                # using sr.dot is important in case weights are a series in wrong order
+                wsum = subset.dot(constr["weights"])
+                if "lower" in constr and wsum < constr["lower"]:
+                    raise ValueError(
+                        msg.format("Lower bound of linear constraint violated")
+                    )
+                elif "upper" in constr and wsum > constr["upper"]:
+                    raise ValueError(
+                        msg.format("Upper bound of linear constraint violated")
+                    )
+                elif "value" in constr and not np.isclose(wsum, constr["value"]):
+                    raise ValueError(
+                        msg.format("Equality condition of linear constraint violated")
+                    )
+            elif typ == "equality":
+                if len(subset.unique()) != 1:
+                    raise ValueError(msg.format("Equality constraint violated."))
 
 
 def check_types(constraints):

--- a/estimagic/optimization/check_constraints.py
+++ b/estimagic/optimization/check_constraints.py
@@ -16,8 +16,9 @@ def check_constraints_are_satisfied(pc, params):
     This should be called before the more specialized constraints are rewritten to
     linear constraints in order to get better error messages!
 
-    We let the checks pass if all parameter values are np.nan. This is useful for the
-    construction of star parameters.
+    We let the checks pass if all "values" are np.nan. This way `process_constraints`
+    can be used on empty params DataFrames which is useful to construct templates for
+    start parameters that can be filled out by the user.
 
     Args:
         pc (list): List of constraints with processed selectors.

--- a/estimagic/optimization/consolidate_constraints.py
+++ b/estimagic/optimization/consolidate_constraints.py
@@ -107,7 +107,7 @@ def _join_overlapping_lists(candidates):
     while len(candidates) > 0:
         new_candidates = _unite_first_with_all_intersecting_elements(candidates)
         if len(candidates) == len(new_candidates):
-            bundles.append(sorted(candidates[0]))
+            bundles.append(sorted(new_candidates[0]))
             candidates = candidates[1:]
         else:
             candidates = new_candidates
@@ -163,7 +163,7 @@ def _consolidate_fixes_with_equality_constraints(fixed_pc, equality_pc, params):
             assert (
                 len(valcounts) == 1
             ), "Equality constrained parameters cannot be fixed to different values."
-            fixed_value.iloc[eq["index"]] = valcounts.idex[0]
+            fixed_value.iloc[eq["index"]] = valcounts.index[0]
 
     return fixed_value
 
@@ -273,7 +273,7 @@ def _plug_equality_constraints_into_selectors(equality_pc, other_pc, params):
     pp = params.copy()
     is_equal_to = pd.Series(index=params.index, data=-1, dtype=int)
     for eq in equality_pc:
-        is_equal_to.iloc[sorted(eq["index"][1:])] = eq["index"][0]
+        is_equal_to.iloc[sorted(eq["index"])[1:]] = sorted(eq["index"])[0]
     pp["_post_replacements"] = is_equal_to
     pp["_is_fixed_to_other"] = is_equal_to >= 0
     helper = pp["_post_replacements"].reset_index(drop=True)
@@ -653,7 +653,7 @@ def _is_redundant(candidate, others):
     if len(others) == 0:
         is_redundant = False
     else:
-        same_type = _split_constraints(others, candidate["type"])
+        same_type, _ = _split_constraints(others, candidate["type"])
         duplicates = [c for c in same_type if c["index"] == candidate["index"]]
         is_redundant = len(duplicates) > 0
 

--- a/estimagic/optimization/process_constraints.py
+++ b/estimagic/optimization/process_constraints.py
@@ -55,21 +55,24 @@ def process_constraints(constraints, params):
             that entail actual transformations and not just fixing parameters.
         pp (pd.DataFrame): Processed params. A copy of params with additional columns:
             - _internal_lower:
-                Lower bounds for the internal parameter vector. Those are derived from
-                the original lower bounds and additional bounds implied by other
-                constraints.
+              Lower bounds for the internal parameter vector. Those are derived from
+              the original lower bounds and additional bounds implied by other
+              constraints.
             - _internal_upper: As _internal_lower but for upper bounds.
             - _internal_free: Boolean column that is true for those parameters over
-                which the optimizer will actually optimize.
+              which the optimizer will actually optimize.
             - _pre_replacements: The j_th element indicates the position of the internal
-                parameter that has to be copied into the j_th position of the external
-                parameter vector when reparametrizing from_internal, before any
-                transformations are applied. Negative if no element has to be copied.
+              parameter that has to be copied into the j_th position of the external
+              parameter vector when reparametrizing from_internal, before any
+              transformations are applied. Negative if no element has to be copied.
             - _post_replacements: As pre_replacements, but applied after the
-                transformations are done.
+              transformations are done.
             - _internal_fixed_value: Contains transformed versions of the fixed values
-                that will become equal to the external fixed values after the
-                kernel transformations are applied.
+              that will become equal to the external fixed values after the
+              kernel transformations are applied.
+            - _is_fixed_to_value: True for parameters that are fixed to a value
+            - _is_fixed_to_other: True for parameters that are fixed to another
+              parameter
 
     """
     with warnings.catch_warnings():

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages
 from setuptools import setup
 
-version = "0.0.21"
+version = "0.0.22"
 
 setup(
     name="estimagic",


### PR DESCRIPTION
## Bug

The new `process_constraints` sometimes fixes all equality constrained parameters, but the first one has to remain free. This is due to a bug in the consolidation of equality constraints. 

## Skillmodels Adjustment

In skillmodels I have to call `process_constraints` with a params DataFrame where all entries in the "value" columns are np.nan. This raised an error because the constraints are not fulfilled. Now the checks are only performed if at least one "value" is not missing. 