### PR TITLE
implement logging

### DIFF
--- a/docs/source/optimization/general_options.rst
+++ b/docs/source/optimization/general_options.rst
@@ -7,18 +7,3 @@ You can pass a dictionary with general options to the
 :func:`~estimagic.optimization.optimize.minimize` or
 :func:`~estimagic.optimization.optimize.maximize` function. The following options are
 available.
-
-**Scaling of the parameter vector**
-
-``estimagic`` is able to automatically scale the parameter vector such that the
-optimizer receives parameters closer to 1. There are two available methods.
-
-1. ``{"scaling": "start_values"}`` divides the parameter vector by the starting
-   values for all starting values not in ``[-1, 1]``.
-
-2. ``{"scaling": "gradient"}`` divides the parameter vector by the inverse of the
-   gradient for each parameter not in ``[-1e-2, 1e-2]``. By default,
-   ``{"scaling_gradient_method": "central", "scaling_gradient_extrapolation": False}``
-   are also set. ``"forward"`` and ``"backward"`` can also be used as a method and
-   extrapolation can be turned on by setting the value to ``True``. Note that without
-   extrapolation, the gradient is computed faster.

--- a/docs/source/optimization/index.rst
+++ b/docs/source/optimization/index.rst
@@ -28,6 +28,7 @@ estimagic if you desire to do so.
    interface
    params
    constraints/index
+   logging
    dashboard
    algorithms
    general_options

--- a/docs/source/optimization/index.rst
+++ b/docs/source/optimization/index.rst
@@ -28,7 +28,7 @@ estimagic if you desire to do so.
    interface
    params
    constraints/index
-   logging
    dashboard
+   logging
    algorithms
    general_options

--- a/docs/source/optimization/logging.rst
+++ b/docs/source/optimization/logging.rst
@@ -1,0 +1,50 @@
+.. _logging:
+
+=========================================
+The *logfile* and *log_options* Arguments
+=========================================
+
+Estimagic can keep a persistent log of the parameter and criterion values tried out
+by an optimizer. For this we use an sqlite database, which makes it easy to read from
+and write to the log-file from several processes or threads. Moreover, it is possible
+to retrieve data from the log-file without ever loading it into memory, which might
+be relevant for very long running.
+
+The log-file is updated instantly when new information becomes available. Thus no data
+is lost when an optimization has to be aborted or a server is shut down for maintenance.
+
+The sqlite database is also used to exchange data between the optimization and the
+dashboard. Thus whenever the dashboard is used, a log file is created, even if no
+logfile is specified by the user.
+
+In addition to parameters and criterion values, we also save all arguments to an
+maximize or minimize in the database as well as other information that can help to
+reproduce an optimization result in the database.
+
+The logfile Argument
+====================
+
+
+``logfile`` can be a string or pathlib.Path that specifies the path to a sqlite3
+database. Typically those files have the file extension ``.db``. If the file does not
+exist, it will be created for you. If it exists, we will create and potentially
+overwrite tables that are used to log the optimization. The details of what estimagic
+will do with your database file are documented in the following function.
+
+
+.. autofunction:: estimagic.logging.create_database.prepare_database
+
+
+
+The log_options Argument
+========================
+
+``log_options`` is a dictionary with keyword arguments that influence the logging
+behavior. The following options are available:
+
+- ``"readme"``: A string with a description of the optimization. This can be helpful
+    to send a message to your future self who might have forgotten why he ran this
+    particular optimization.
+- ``"exclude_tables"``: A list with names of tables from above that should be excluded
+    from the logging. This can be used to save disk space and a bit of time in each
+    iteration. Note that the tables will still be generated, but not updated.

--- a/estimagic/optimization/optimize.py
+++ b/estimagic/optimization/optimize.py
@@ -36,37 +36,49 @@ def maximize(
     dashboard=False,
     db_options=None,
 ):
-    """
-    Maximize *criterion* using *algorithm* subject to *pc* and bounds.
+    """Maximize *criterion* using *algorithm* subject to *pc* and bounds.
+
+    Each argument except for ``general_options`` can also be replaced by a list of
+    arguments in which case several optimizations are run in parallel. For this, either
+    all arguments must be lists of the same length, or some arguments can be provided
+    as single arguments in which case they are automatically broadcasted.
 
     Args:
-        criterion (function):
+        criterion (function or list of functions):
             Python function that takes a pandas DataFrame with parameters as the first
             argument and returns a scalar floating point value.
 
-        params (pd.DataFrame):
+        params (pd.DataFrame or list of pd.DataFrames):
             See :ref:`params`.
 
-        algorithm (str):
+        algorithm (str or list of strings):
             specifies the optimization algorithm. See :ref:`list_of_algorithms`.
 
-        criterion_kwargs (dict):
+        criterion_kwargs (dict or list of dicts):
             additional keyword arguments for criterion
 
-        constraints (list):
+        constraints (list or list of lists):
             list with constraint dictionaries. See for details.
 
         general_options (dict):
-            additional configurations for the optimization.
+            additional configurations for the optimization
 
-        algo_options (dict):
-            algorithm specific configurations for the optimization.
+        algo_options (dict or list of dicts):
+            algorithm specific configurations for the optimization
+
+        logfile (str or pathlib.Path): Path to an sqlite3 file which typically has the
+            file extension ``.db``. If the file does not exist, it will be created. See
+            :ref:`logging` for details.
+
+        log_options (dict): Keyword arguments to influence the logging. See
+            :ref:`logging` for details.
 
         dashboard (bool):
-            whether to create and show a dashboard.
+            whether to create and show a dashboard. See :ref:`dashboard` for details.
 
         db_options (dict):
-            dictionary with kwargs to be supplied to the run_server function.
+            dictionary with kwargs to be supplied to the run_server function. See
+                :ref:`dashboard` for details.
 
     """
 
@@ -103,11 +115,17 @@ def minimize(
     constraints=None,
     general_options=None,
     algo_options=None,
+    logfile=None,
+    log_options=None,
     dashboard=False,
     db_options=None,
 ):
     """Minimize *criterion* using *algorithm* subject to *constraints* and bounds.
-    Run several optimizations if called by lists of inputs.
+
+    Each argument except for ``general_options`` can also be replaced by a list of
+    arguments in which case several optimizations are run in parallel. For this, either
+    all arguments must be lists of the same length, or some arguments can be provided
+    as single arguments in which case they are automatically broadcasted.
 
     Args:
         criterion (function or list of functions):
@@ -132,11 +150,19 @@ def minimize(
         algo_options (dict or list of dicts):
             algorithm specific configurations for the optimization
 
+        logfile (str or pathlib.Path): Path to an sqlite3 file which typically has the
+            file extension ``.db``. If the file does not exist, it will be created. See
+            :ref:`logging` for details.
+
+        log_options (dict): Keyword arguments to influence the logging. See
+            :ref:`logging` for details.
+
         dashboard (bool):
-            whether to create and show a dashboard
+            whether to create and show a dashboard. See :ref:`dashboard` for details.
 
         db_options (dict):
-            dictionary with kwargs to be supplied to the run_server function.
+            dictionary with kwargs to be supplied to the run_server function. See
+                :ref:`dashboard` for details.
 
     """
 


### PR DESCRIPTION
## Goal

Add a basic version of persistent logging. For now we will only save the criterion and parameter history. Getting the gradients and convergence criteria out of the different algorithms will be done in a separate PR. Using the database in the dashboard will also be done in a separate PR. 

## Tasks

- [x] Fix an interface and write documentation
- [ ] Create all databases (in the case of parallel optimizations) before the first optimization or the dashboard actually start. 
- [ ] Update the database in `internal_criterion`
- [ ] Replace the counter in the criterion_function by something thread safe based on the database. 