### PR TITLE
Fix memory consumption error on rtd.

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,10 @@
+version: 2
+
+build:
+  image: latest
+
+python:
+  version: 3.7
+
+conda:
+  environment: docs/environment.yml

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -6,3 +6,4 @@ dependencies:
   - nbsphinx
   - sphinx
   - sphinx_rtd_theme
+  - sphinxcontrib-bibtex

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,0 +1,8 @@
+channels:
+  - conda-forge
+dependencies:
+  - python=3.7
+  - ipython
+  - nbsphinx
+  - sphinx
+  - sphinx_rtd_theme

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -52,6 +52,17 @@ extensions = [
 
 autodoc_member_order = "bysource"
 
+autodoc_mock_imports = [
+    "cloudpickle",
+    "numba",
+    "numdifftools",
+    "numpy",
+    "pandas",
+    "pytest",
+    "pygmo",
+    "scipy",
+]
+
 extlinks = {
     "ghuser": ("https://github.com/%s", "@"),
     "gh": ("https://github.com/OpenSourceEconomics/estimagic/pulls/%s", "#"),

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -80,7 +80,7 @@ intersphinx_mapping = {
 }
 
 linkcheck_ignore = [
-    r"http://tinyurl\.com/*.",
+    r"https://tinyurl\.com/*.",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -106,7 +106,7 @@ else:
 
 # -- Options for nbsphinx  ----------------------------------------
 # Execute notebooks before conversion: 'always', 'never', 'auto' (default)
-nbsphinx_execute = "always"
+nbsphinx_execute = "never"
 
 
 # -- Options for HTML output ----------------------------------------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -43,6 +43,7 @@ extensions = [
     "sphinx.ext.todo",
     "sphinx.ext.coverage",
     "sphinx.ext.extlinks",
+    "sphinx.ext.intersphinx",
     "sphinx.ext.mathjax",
     "sphinx.ext.viewcode",
     "sphinx.ext.napoleon",
@@ -53,7 +54,9 @@ extensions = [
 autodoc_member_order = "bysource"
 
 autodoc_mock_imports = [
+    "bokeh",
     "cloudpickle",
+    "fuzzywuzzy",
     "numba",
     "numdifftools",
     "numpy",
@@ -61,12 +64,24 @@ autodoc_mock_imports = [
     "pytest",
     "pygmo",
     "scipy",
+    "sqlalchemy",
+    "tornado",
 ]
 
 extlinks = {
     "ghuser": ("https://github.com/%s", "@"),
     "gh": ("https://github.com/OpenSourceEconomics/estimagic/pulls/%s", "#"),
 }
+
+intersphinx_mapping = {
+    "numpy": ("https://docs.scipy.org/doc/numpy", None),
+    "pandas": ("https://pandas.pydata.org/pandas-docs/stable", None),
+    "python": ("https://docs.python.org/3.6", None),
+}
+
+linkcheck_ignore = [
+    r"http://tinyurl\.com/*.",
+]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/estimagic/optimization/optimize.py
+++ b/estimagic/optimization/optimize.py
@@ -59,7 +59,7 @@ def maximize(
     as single arguments in which case they are automatically broadcasted.
 
     Args:
-        criterion (function or list of functions):
+        criterion (callable or list of callables):
             Python function that takes a pandas DataFrame with parameters as the first
             argument and returns a scalar floating point value.
 

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,9 +1,0 @@
-version: 2
-
-sphinx:
-  configuration: docs/source/conf.py
-python:
-  version: 3.7
-
-conda:
-  environment: docs/source/rtd_environment.yml

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,10 @@ basepython = python
 [testenv:pytest]
 setenv =
     CONDA_DLL_SEARCH_MODIFICATION_ENABLE = 1
+conda_channels =
+    opensourceeconomics
+    conda-forge
+    defaults
 conda_deps =
     bokeh >= 1.3
     fuzzywuzzy
@@ -24,10 +28,6 @@ conda_deps =
     scipy >= 1.2.1
     sqlalchemy >= 1.3
     numba
-conda_channels =
-    opensourceeconomics
-    conda-forge
-    defaults
 commands = pytest estimagic
 
 
@@ -43,7 +43,8 @@ commands =
 
 [testenv:sphinx]
 changedir = docs/source
-deps =
+conda_channels = conda-forge
+conda_deps =
     ipython
     nbsphinx
     sphinx

--- a/tox.ini
+++ b/tox.ini
@@ -42,7 +42,7 @@ commands =
     pre-commit run --all-files
 
 [testenv:sphinx]
-changedir = docs
+changedir = docs/source
 deps =
     ipython
     nbsphinx
@@ -51,8 +51,8 @@ deps =
     sphinxcontrib-bibtex
 commands =
     # Add W flag to builds so that warnings become errors.
-    sphinx-build -nWT -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
-    sphinx-build -nWT -b linkcheck -d {envtmpdir}/doctrees . {envtmpdir}/linkcheck
+    sphinx-build -nT -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
+    sphinx-build -nT -b linkcheck -d {envtmpdir}/doctrees . {envtmpdir}/linkcheck
 
 [doc8]
 ignore =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = pytest, linting,
+envlist = pytest, linting, sphinx
 skipsdist = True
 skip_missing_interpreters = True
 
@@ -44,8 +44,11 @@ commands =
 [testenv:sphinx]
 changedir = docs
 deps =
+    ipython
+    nbsphinx
     sphinx
     sphinx_rtd_theme
+    sphinxcontrib-bibtex
 commands =
     # Add W flag to builds so that warnings become errors.
     sphinx-build -nWT -b html -d {envtmpdir}/doctrees . {envtmpdir}/html


### PR DESCRIPTION
The conda environment takes more memory than the 2GB provided by rtd and thus, the build sometimes crashes. The changes make the documentation more static by mocking imports and using the notebooks as they are and reducing packages in the environment.

### Features

- The documentation has its own, smaller environment. Imports of NumPy, etc. are mocked.
- sphinx check are now executed on Linux
- Warnings while building docs are displayed but are not recognized as errors. Needs to be resolved at some other point in time.