### PR TITLE
Fix ML estimation implemented in #107.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
     -   id: debug-statements
     -   id: end-of-file-fixer
 -   repo: https://github.com/asottile/reorder_python_imports
-    rev: v1.8.0
+    rev: v1.9.0
     hooks:
     -   id: reorder-python-imports
         types: [python]
@@ -15,7 +15,7 @@ repos:
 #     hooks:
 #     -   id: check-yaml
 -   repo: https://github.com/asottile/blacken-docs
-    rev: v1.3.0
+    rev: v1.4.0
     hooks:
     -   id: blacken-docs
         additional_dependencies: [black]

--- a/estimagic/estimation/estimate.py
+++ b/estimagic/estimation/estimate.py
@@ -146,13 +146,13 @@ def maximize_log_likelihood(
         db_options=db_options,
     )
 
-    contributions = [
+    contribs_and_cp_data = [
         args_one_run["criterion"](
             args_one_run["params"], **args_one_run["criterion_kwargs"]
-        )[0]
+        )
         for args_one_run in arguments
     ]
-    n_contributions = [len(contribs) for contribs in contributions]
+    n_contributions = [len(c_and_cp[0]) for c_and_cp in contribs_and_cp_data]
 
     if isinstance(results, list):
         for result, n_contribs in zip(results, n_contributions):

--- a/estimagic/estimation/estimate.py
+++ b/estimagic/estimation/estimate.py
@@ -102,16 +102,16 @@ def maximize_log_likelihood(
 
     """
     if isinstance(log_like_obs, list):
-        wrapped_loglikeobs = [
+        extended_loglikelobs = [
             expand_criterion_output(crit_func) for crit_func in log_like_obs
         ]
         wrapped_loglikeobs = [
             aggregate_criterion_output(np.mean)(crit_func)
-            for crit_func in wrapped_loglikeobs
+            for crit_func in extended_loglikelobs
         ]
     else:
-        wrapped_loglikeobs = expand_criterion_output(log_like_obs)
-        wrapped_loglikeobs = aggregate_criterion_output(np.mean)(wrapped_loglikeobs)
+        extended_loglikelobs = expand_criterion_output(log_like_obs)
+        wrapped_loglikeobs = aggregate_criterion_output(np.mean)(extended_loglikelobs)
 
     results = maximize(
         wrapped_loglikeobs,
@@ -131,7 +131,7 @@ def maximize_log_likelihood(
     # To convert the mean log likelihood in the results dictionary to the log
     # likelihood, get the length of contributions for each optimization.
     arguments = process_optimization_arguments(
-        criterion=log_like_obs,
+        criterion=extended_loglikelobs,
         params=params,
         algorithm=algorithm,
         criterion_kwargs=criterion_kwargs,
@@ -147,7 +147,7 @@ def maximize_log_likelihood(
     )
 
     contributions = [
-        expand_criterion_output(args_one_run["criterion"])(
+        args_one_run["criterion"](
             args_one_run["params"], **args_one_run["criterion_kwargs"]
         )[0]
         for args_one_run in arguments

--- a/estimagic/estimation/estimate.py
+++ b/estimagic/estimation/estimate.py
@@ -146,16 +146,13 @@ def maximize_log_likelihood(
         db_options=db_options,
     )
 
-    n_contributions = [
-        len(
-            list(
-                args_one_run["criterion"](
-                    args_one_run["params"], **args_one_run["criterion_kwargs"]
-                )
-            )
-        )
+    contributions = [
+        expand_criterion_output(args_one_run["criterion"])(
+            args_one_run["params"], **args_one_run["criterion_kwargs"]
+        )[0]
         for args_one_run in arguments
     ]
+    n_contributions = [len(contribs) for contribs in contributions]
 
     if isinstance(results, list):
         for result, n_contribs in zip(results, n_contributions):

--- a/estimagic/logging/create_database.py
+++ b/estimagic/logging/create_database.py
@@ -7,6 +7,7 @@ recommended way of doing things in sqlalchemy and makes sense for database code.
 from pathlib import Path
 
 import numpy as np
+import pandas as pd
 from sqlalchemy import Column
 from sqlalchemy import create_engine
 from sqlalchemy import event
@@ -178,7 +179,7 @@ def prepare_database(
     append_rows(database, "db_options", {"value": db_options})
 
     if comparison_plot_data is None:
-        comparison_plot_data = np.array([np.nan])
+        comparison_plot_data = pd.DataFrame({"value": [np.nan]})
     append_rows(database, "comparison_plot", {"value": comparison_plot_data})
 
     return database

--- a/estimagic/logging/create_database.py
+++ b/estimagic/logging/create_database.py
@@ -136,8 +136,6 @@ def prepare_database(
         to the database can be accessed via ``database.bind``.
 
     """
-    if comparison_plot_data is None:
-        comparison_plot_data = {"value": np.array([np.nan])}
     db_options = {} if db_options is None else db_options
     gradient_status = float(gradient_status)
     database = load_database(path)
@@ -178,6 +176,10 @@ def prepare_database(
     append_rows(database, "optimization_status", {"value": optimization_status})
     append_rows(database, "gradient_status", {"value": gradient_status})
     append_rows(database, "db_options", {"value": db_options})
+
+    if comparison_plot_data is None:
+        comparison_plot_data = np.array([np.nan])
+    append_rows(database, "comparison_plot", {"value": comparison_plot_data})
 
     return database
 


### PR DESCRIPTION
There are two fixes necessary to the interface implementation.

- The initial entry in the comparison plot data has to be a DataFrame whereas the remaining entries are NumPy Arrays of the ``"value"`` column. I forgot to save the DataFrame to the database.

- The conversion from mean log like to log like needed the number of contributions. This was unstable as the user-defined criterion function could have one or two returns.