### PR TITLE
Remove name column from params.

### DIFF
--- a/docs/source/explanations/optimization/internal_optimizers.rst
+++ b/docs/source/explanations/optimization/internal_optimizers.rst
@@ -54,13 +54,13 @@ optimizer. Neither the mandatory arguments, nor the bounds should have a default
 
 The only non-trivial argument is ``criterion_and_derivative``. This is a callable that
 accepts three arguments and returns the output of the user provided criterion function
-(float or dict), the output of a user provided or numerical derivative (np.ndarray) or
+(float or dict), the output of a user provided or numerical derivative (numpy.ndarray) or
 both. For more details on valid outputs of the criterion function see
 :ref:`maximize_and_minimize`.
 
 The arguments  of criterion_and_derivative are:
 
-- x (np.ndarray): A one dimensional vector with free parameters
+- x (numpy.ndarray): A one dimensional vector with free parameters
 - task (str): One of "criterion", "derivative" and "criterion_and_derivative"
 - algorithm_info (dict): Dict with the following entries:
     - "primary_criterion_entry": For optimizers that minimize a scalar function this has

--- a/estimagic/differentiation/derivatives.py
+++ b/estimagic/differentiation/derivatives.py
@@ -301,7 +301,7 @@ def _consolidate_one_step_derivatives(candidates, preference_order):
         entries are preferred.
 
     Returns:
-        consolidated (np.ndarray): Array of same shape as input derivative estimates.
+        consolidated (numpy.ndarray): Array of same shape as input derivative estimates.
 
     """
     preferred, others = preference_order[0], preference_order[1:]
@@ -328,7 +328,7 @@ def _consolidate_extrapolated(candidates):
             and their error estimates.
 
     Returns:
-        consolidated (np.ndarray): Array of same shape as input derivative estimates.
+        consolidated (numpy.ndarray): Array of same shape as input derivative estimates.
 
     """
     # first find minimum over steps for each method
@@ -371,9 +371,9 @@ def _compute_richardson_candidates(jac_candidates, steps, n_steps):
             - Keys correspond to the method used, i.e. forward, backward or central
             differences and the number of terms used in the Richardson extrapolation.
             - Values represent the corresponding derivative estimate and error
-            estimate, stored as np.ndarrays in a sub-dictionary under "derivative" and
-            "error" respectively, with the first dimensions coinciding with that of an
-            element of ``jac_candidates`` and depending on num_terms, possibly one
+            estimate, stored as numpy.ndarrays in a sub-dictionary under "derivative"
+            and "error" respectively, with the first dimensions coinciding with that of
+            an element of ``jac_candidates`` and depending on num_terms, possibly one
             further dimension.
 
     """
@@ -399,20 +399,20 @@ def _get_best_estimate_single_method(derivative, errors):
     approximations which result in the lowest error element wise.
 
     Args:
-        derivative (np.ndarray): Derivative estimates from Richardson approximation.
+        derivative (numpy.ndarray): Derivative estimates from Richardson approximation.
             First axis (axis 0) denotes the potentially multiple estimates. Following
             dimensions represent the dimension of the derivative, i.e. for a classical
             gradient ``derivative`` has 2 dimensions, while for a classical jacobian
             ``derivative`` has 3 dimensions.
-        errors (np.ndarray): Error estimates of ``derivative`` estimates. Has the same
-            shape as ``derivative``.
+        errors (numpy.ndarray): Error estimates of ``derivative`` estimates. Has the
+            same shape as ``derivative``.
 
     Returns:
-        derivative_minimal (np.ndarray): Best derivate estimates chosen with respect
+        derivative_minimal (numpy.ndarray): Best derivate estimates chosen with respect
             to minimizing ``errors``. Note that the best values are selected
             element-wise. Has shape ``(derivative.shape[1], derivative.shape[2])``.
 
-        error_minimal (np.ndarray): Minimal errors selected element-wise along axis
+        error_minimal (numpy.ndarray): Minimal errors selected element-wise along axis
             0 of ``errors``.
 
     """
@@ -447,7 +447,7 @@ def _get_best_estimate_along_methods(derivatives, errors):
             in ``derivatives``.
 
     Returns:
-        jac_minimal (np.ndarray): The optimal derivative estimate over different
+        jac_minimal (numpy.ndarray): The optimal derivative estimate over different
             methods.
 
     """

--- a/estimagic/differentiation/generate_steps.py
+++ b/estimagic/differentiation/generate_steps.py
@@ -222,19 +222,19 @@ def _rescale_to_accomodate_bounds(
     """Rescale steps to make them compatible with bounds unless this violates min_steps.
 
     Args:
-        base_steps (np.ndarray, optional): 1d array of the same length as x.
+        base_steps (numpy.ndarray, optional): 1d array of the same length as x.
             base_steps * scaling_factor is the absolute value of the first (and possibly
             only) step used in the finite differences approximation of the derivative.
-        pos (np.ndarray): Array with positive steps of shape (n_steps, len(x))
-        neg (np.ndarray): Array with negative steps of shape (n_steps, len(x))
-        lower_step_bounds (np.ndarray): Lower bounds for steps.
-        upper_step_bounds (np.ndarray): Upper bounds for steps.
-        min_steps (np.ndarray): Minimal possible step sizes that can be chosen
+        pos (numpy.ndarray): Array with positive steps of shape (n_steps, len(x))
+        neg (numpy.ndarray): Array with negative steps of shape (n_steps, len(x))
+        lower_step_bounds (numpy.ndarray): Lower bounds for steps.
+        upper_step_bounds (numpy.ndarray): Upper bounds for steps.
+        min_steps (numpy.ndarray): Minimal possible step sizes that can be chosen
             to accomodate bounds. Needs to have same length as x.
 
     Returns:
-        pos (np.ndarray): Copy of pos with rescaled steps.
-        neg (np.ndarray): Copy of neg with rescaled steps.
+        pos (numpy.ndarray): Copy of pos with rescaled steps.
+        neg (numpy.ndarray): Copy of neg with rescaled steps.
 
     """
     with warnings.catch_warnings():
@@ -265,5 +265,6 @@ def _make_exact(h):
 
     This is important when calculating numerical derivates and is accomplished by adding
     1.0 and then subtracting 1.0.
+
     """
     return (h + 1.0) - 1.0

--- a/estimagic/differentiation/richardson_extrapolation.py
+++ b/estimagic/differentiation/richardson_extrapolation.py
@@ -28,9 +28,10 @@ def richardson_extrapolation(sequence, steps, method="central", num_terms=None):
 
 
     Args:
-        sequence (np.ndarray): The sequence of which we want to approximate the limit.
-            Has dimension (k x n x m), where k denotes the number of sequence elements
-            and an element ``sequence[l, :, :]`` denotes the (n x m) dimensional element
+        sequence (numpy.ndarray): The sequence of which we want to approximate the
+            limit. Has dimension (k x n x m), where k denotes the number of sequence
+            elements and an element ``sequence[l, :, :]`` denotes the (n x m)
+            dimensional element
 
         steps (namedtuple): Namedtuple with the field names pos and neg. Each field
             contains a numpy array of shape (n_steps, len(x)) with the steps in
@@ -43,8 +44,8 @@ def richardson_extrapolation(sequence, steps, method="central", num_terms=None):
             ``steps.shape[0] - 1``.
 
     Returns:
-        limit (np.ndarray): The refined limit.
-        error (np.ndarray): The error approximation of ``limit``.
+        limit (numpy.ndarray): The refined limit.
+        error (numpy.ndarray): The error approximation of ``limit``.
 
     """
     seq_len = sequence.shape[0]
@@ -114,7 +115,7 @@ def _richardson_coefficients(num_terms, step_ratio, exponentiation_step, order):
             For central difference derivative approximation ``order`` = 2.
 
     Returns:
-        coef (np.ndarray): Richardson coefficients, array has length num_terms + 1.
+        coef (numpy.ndarray): Richardson coefficients, array has length num_terms + 1.
 
     Example:
     >>> import numpy as np
@@ -141,19 +142,19 @@ def _estimate_error(new_seq, old_seq, richardson_coef):
     """Estimate error of multiple Richardson limit approximation.
 
     Args:
-        new_seq (np.ndarray): Multiple estimates of the limit of ``old_seq``. The last
-            two dimensions coincide with those of ``old_seq``. The first dimensions
+        new_seq (numpy.ndarray): Multiple estimates of the limit of ``old_seq``. The
+            last two dimensions coincide with those of ``old_seq``. The first dimensions
             denotes the number of different estimates.
 
-        old_seq (np.ndarray): The sequence of which we want to approximate the limit.
+        old_seq (numpy.ndarray): The sequence of which we want to approximate the limit.
             Has dimension (k x n x m), where k denotes the number of sequence elements
             and an element ``sequence[l, :, :]`` denotes the (n x m) dimensional element
 
-        richardson_coef (np.ndarray): Richardson coefficients. See function
+        richardson_coef (numpy.ndarray): Richardson coefficients. See function
             ``_richardson_coefficient`` for details.
 
     Returns:
-        abserr (np.ndarray): The error estimate for each limit approximation in
+        abserr (numpy.ndarray): The error estimate for each limit approximation in
             ``new_seq``.
 
     """
@@ -253,7 +254,7 @@ def _compute_step_ratio(steps):
     """Compute the step ratio used in producing ``steps``.
 
     Args:
-        steps (np.ndarray): Array of shape (n_steps, len(x)) with the steps in the
+        steps (numpy.ndarray): Array of shape (n_steps, len(x)) with the steps in the
             corresponding direction.
 
     Returns:

--- a/estimagic/estimation/weighting_matrix.py
+++ b/estimagic/estimation/weighting_matrix.py
@@ -31,7 +31,7 @@ def weighting_matrix(moment_func, data, estimation_principle, weight_type="diago
             'optimal', 'optimal_bootstrap', 'diagonal', 'diagonal_bootstrap']
 
     Returns:
-        weights (np.ndarray): A positive semi-definite weighting matrix for minimum
+        weights (numpy.ndarray): A positive semi-definite weighting matrix for minimum
             distance estimators.
 
     """

--- a/estimagic/optimization/internal_criterion_template.py
+++ b/estimagic/optimization/internal_criterion_template.py
@@ -60,7 +60,7 @@ def internal_criterion_and_derivative_template(
     That is the reason why this function is called a template.
 
     Args:
-        x (np.ndarray): 1d numpy array with internal parameters.
+        x (numpy.ndarray): 1d numpy array with internal parameters.
         task (str): One of "criterion", "derivative" and "criterion_and_derivative".
         direction (str): One of "maximize" or "minimize"
         criterion (callable): (partialed) user provided criterion function that takes a
@@ -114,7 +114,7 @@ def internal_criterion_and_derivative_template(
         cache_size (int): Number of evaluations that are kept in cache. Default 10.
 
     Returns:
-        float, np.ndarray or tuple: If task=="criterion" it returns the output of
+        float, numpy.ndarray or tuple: If task=="criterion" it returns the output of
             criterion which can be a float or 1d numpy array. If task=="derivative" it
             returns the first derivative of criterion, which is a numpy array.
             If task=="criterion_and_derivative" it returns both as a tuple.

--- a/estimagic/optimization/kernel_transformations.py
+++ b/estimagic/optimization/kernel_transformations.py
@@ -61,7 +61,7 @@ def covariance_to_internal_jacobian(external_values, constr):
         \frac{\mathrm{d}x}{\mathrm{d}c} = (\frac{\mathrm{d}c}{\mathrm{d}x})^{-1}
 
     Args:
-        external_values (np.ndarray): Row-wise half-vectorized covariance matrix
+        external_values (numpy.ndarray): Row-wise half-vectorized covariance matrix
 
     Returns:
         deriv: The Jacobian matrix.
@@ -114,7 +114,7 @@ def covariance_from_internal_jacobian(internal_values, constr):
     where :math:`c := \text{external}` and :math:`x := \text{internal}`.
 
     Args:
-        internal_values (np.ndarray): Cholesky factors stored in an "internal"
+        internal_values (numpy.ndarray): Cholesky factors stored in an "internal"
             format.
 
     Returns:
@@ -160,7 +160,7 @@ def sdcorr_to_internal_jacobian(external_values, constr):
         \frac{\mathrm{d}x}{\mathrm{d}p} = (\frac{\mathrm{d}p}{\mathrm{d}x})^{-1}
 
     Args:
-        external_values (np.ndarray): Row-wise half-vectorized modified correlation
+        external_values (numpy.ndarray): Row-wise half-vectorized modified correlation
             matrix.
 
     Returns:
@@ -226,7 +226,7 @@ def sdcorr_from_internal_jacobian(internal_values, constr):
         \frac{\mathrm{d}p}{\mathrm{d}x} = T \frac{\mathrm{d}p'}{\mathrm{d}x'} D
 
     Args:
-        internal_values (np.ndarray): Cholesky factors stored in an "internal"
+        internal_values (numpy.ndarray): Cholesky factors stored in an "internal"
             format.
 
     Returns:
@@ -292,7 +292,7 @@ def probability_to_internal_jacobian(external_values, constr):
         ]
 
     Args:
-        external_values (np.ndarray): Array of probabilities; sums to one.
+        external_values (numpy.ndarray): Array of probabilities; sums to one.
 
     Returns:
         deriv: The Jacobian matrix.
@@ -326,7 +326,7 @@ def probability_from_internal_jacobian(internal_values, constr):
     .. math::  J(f)(x) = \frac{1}{\sigma} I_m - \frac{1}{\sigma^2} 1 x^\top
 
     Args:
-        internal_values (np.ndarray): Internal (positive) values.
+        internal_values (numpy.ndarray): Internal (positive) values.
 
     Returns:
         deriv: The Jacobian matrix.
@@ -378,7 +378,7 @@ def _elimination_matrix(dim):
         dim (int): The dimension.
 
     Returns:
-        eliminator (np.ndarray): The elimination matrix.
+        eliminator (numpy.ndarray): The elimination matrix.
 
     Examples:
     >>> import numpy as np
@@ -424,7 +424,7 @@ def _duplication_matrix(dim):
         dim (int): The dimension.
 
     Returns:
-        duplicator (np.ndarray): The duplication matrix.
+        duplicator (numpy.ndarray): The duplication matrix.
 
     Example:
     >>> import numpy as np
@@ -466,7 +466,7 @@ def _transformation_matrix(dim):
         dim (int): The dimension.
 
     Returns:
-        transformer (np.ndarray): The transformation matrix.
+        transformer (numpy.ndarray): The transformation matrix.
 
     Example:
     >>> import numpy as np
@@ -541,7 +541,7 @@ def _unit_vector_or_zeros(index, size):
         size (int): Dimension of the resulting vector.
 
     Returns:
-        u (np.ndarray): The unit or zero vector.
+        u (numpy.ndarray): The unit or zero vector.
 
     Example:
     >>> import numpy as np

--- a/estimagic/optimization/optimize.py
+++ b/estimagic/optimization/optimize.py
@@ -506,12 +506,12 @@ def _single_optimize(
     _check_params(params)
 
     processed_constraints, processed_params = process_constraints(constraints, params)
-    params = _add_name_and_group_columns_to_params(params)
+    params_with_name_and_group = _add_name_and_group_columns_to_params(params)
 
     # This can only be saved in problem_data now, because we need the group and name
     # columns in the dashboard but we could not add any columns before calling
     # process_constraints.
-    problem_data["params"] = params
+    problem_data["params"] = params_with_name_and_group
 
     # get internal parameters and bounds
     x = reparametrize_to_internal(

--- a/estimagic/optimization/reparametrize.py
+++ b/estimagic/optimization/reparametrize.py
@@ -44,8 +44,8 @@ def reparametrize_to_internal(external, internal_free, processed_constraints):
     """Convert a params DataFrame into a numpy array of internal parameters.
 
     Args:
-        external (np.ndarray): 1d array with external parameters.
-        internal_free (np.ndarray): 1d array of lenth n_external that determines
+        external (numpy.ndarray): 1d array with external parameters.
+        internal_free (numpy.ndarray): 1d array of lenth n_external that determines
             which parameters are free.
         processed_constraints (list): Processed and consolidated constraints. The
             processed constraints contain information on the transformations that have
@@ -154,8 +154,9 @@ def convert_external_derivative_to_internal(
             element contains the position a parameter in the transformed parameter
             vector that has to be copied to duplicated and copied to the i_th position
             of the external parameter vector.
-        pre_replace_jac (np.ndarray): 2d Array with the jacobian of pre_replace
-        post_replacment_jacobian (np.ndarray): 2d Array with the jacobian post_replace
+        pre_replace_jac (numpy.ndarray): 2d Array with the jacobian of pre_replace
+        post_replacment_jacobian (numpy.ndarray): 2d Array with the jacobian
+            post_replace
 
     Returns:
         deriv (numpy.ndarray): The gradient or Jacobian.
@@ -277,7 +278,7 @@ def pre_replace_jacobian(pre_replacements, dim_in):
         dim_in (int): Dimension of the internal parameters.
 
     Returns:
-        jacobian (np.ndarray): The jacobian.
+        jacobian (numpy.ndarray): The jacobian.
 
     Examples:
         >>> # Note: The example is the same as in the doctest of pre_replace
@@ -368,7 +369,7 @@ def post_replace_jacobian(post_replacements):
         dim (int): The dimension of the external parameters.
 
     Returns:
-        jacobian (np.ndarray): The Jacobian.
+        jacobian (numpy.ndarray): The Jacobian.
 
     Examples:
         >>> # Note: the example is the same as in the doctest of post_replace

--- a/estimagic/optimization/utilities.py
+++ b/estimagic/optimization/utilities.py
@@ -272,7 +272,7 @@ def calculate_trustregion_initial_radius(x):
     It is calculated as :math:`0.1\max(\|x\|_{\infty}, 1)`.
 
     Args:
-        x (np.ndarray): the start parameter values.
+        x (numpy.ndarray): the start parameter values.
 
     Returns:
         trust_radius (float): initial trust radius


### PR DESCRIPTION
The `name` and `group` columns are actually only needed in the dashboard and can cause problems in the criterion function. Now we just add them before saving start parameters in the database and never call the criterion functions with the extended parameters. 