### PR TITLE
Add Scipy's Least Squares Optimizer

### DIFF
--- a/docs/source/how_to_guides/optimization/how_to_use_the_dashboard.rst
+++ b/docs/source/how_to_guides/optimization/how_to_use_the_dashboard.rst
@@ -129,5 +129,5 @@ For the following we assume that you have already started an optimization on the
 
 6. That's it. For more information on ``ssh`` and how to configure your remote machine,
    check out `Working remotely in shell environments
-   <https://github.com/OpenSourceEconomics/hackathon/blob/master/
-   material/2019_08_20/17_shell_remote.pdf>`_.
+   <https://github.com/OpenSourceEconomics/
+   ose-meetup/blob/master/material/2019_08_20/17_shell_remote.pdf>`_.

--- a/docs/source/refs.bib
+++ b/docs/source/refs.bib
@@ -10,7 +10,7 @@
 
   ISBN                     = {9780898713640},
   Lccn                     = {lc95051776},
-  Url                      = {https://books.google.com/books?id=RtxcWd0eBD0C}
+  Url                      = {https://books.google.de/books?id=RtxcWd0eBD0C&redir_esc=y}
 }
 
 @Book{Hansen2019,

--- a/estimagic/logging/read_log.py
+++ b/estimagic/logging/read_log.py
@@ -112,7 +112,7 @@ def _process_path_or_database(path_or_database):
     >>> from sqlalchemy import MetaData
     >>> database = MetaData()
     >>> _process_path_or_database(database)
-    {'path': None, 'metadata': MetaData(bind=None), 'fast_logging': False}
+    {'path': None, 'metadata': MetaData(), 'fast_logging': False}
 
     """
     res = {"path": None, "metadata": None, "fast_logging": False}

--- a/estimagic/optimization/scipy_optimizers.py
+++ b/estimagic/optimization/scipy_optimizers.py
@@ -955,6 +955,43 @@ def scipy_trust_constr(
     return _process_scipy_result(res)
 
 
+def scipy_least_squares(
+    criterion_and_derivative,
+    x,
+    lower_bounds,
+    upper_bounds
+):
+    """
+    TODO: Add Documentation.
+
+    Returns:
+        dict: See :ref:`internal_optimizer_output` for details.
+
+    """
+    algo_info = DEFAULT_ALGO_INFO.copy()
+    algo_info["name"] = "scipy_least_squares"
+    func = functools.partial(
+        criterion_and_derivative,
+        task="criterion",
+        algorithm_info=algo_info,
+    )
+
+    gradient = functools.partial(
+        criterion_and_derivative, task="derivative", algorithm_info=algo_info
+    )
+
+    res = scipy.optimize.least_squares(
+        fun=func,
+        x0=x,
+        jac=gradient,
+        # Don't use _get_scipy_bounds, b.c. least_squares uses np.inf
+        bounds=(lower_bounds, upper_bounds),
+        # TODO: Check for additional parameters that can be used here
+    )
+
+    return _process_scipy_result(res)
+
+
 def _process_scipy_result(scipy_results_obj):
     # using get with defaults to access dict elements is just a safety measure
     raw_res = {**scipy_results_obj}

--- a/estimagic/optimization/scipy_optimizers.py
+++ b/estimagic/optimization/scipy_optimizers.py
@@ -956,14 +956,14 @@ def scipy_trust_constr(
     return _process_scipy_result(res)
 
 
-def scipy_least_squares(
+def _scipy_least_squares(
     criterion_and_derivative,
     x,
     lower_bounds,
     upper_bounds,
     *,
-    convergence_relative_criterion_tolerance=CONVERGENCE_RELATIVE_CRITERION_TOLERANCE,
-    convergence_relative_gradient_tolerance=CONVERGENCE_RELATIVE_GRADIENT_TOLERANCE,
+    convergence_relative_criterion_tol=CONVERGENCE_RELATIVE_CRITERION_TOLERANCE,
+    convergence_relative_gradient_tol=CONVERGENCE_RELATIVE_GRADIENT_TOLERANCE,
     stopping_max_criterion_evaluations=STOPPING_MAX_CRITERION_EVALUATIONS,
     relative_step_size_diff_approx=None,
     tr_solver=None,
@@ -987,7 +987,7 @@ def scipy_least_squares(
         tr_solver_options = {}
 
     algo_info = DEFAULT_ALGO_INFO.copy()
-    algo_info["name"] = "scipy_least_squares"
+    algo_info["name"] = f"scipy_ls_{method}"
     func = functools.partial(
         criterion_and_derivative,
         task="criterion",
@@ -1005,8 +1005,8 @@ def scipy_least_squares(
         # Don't use _get_scipy_bounds, b.c. least_squares uses np.inf
         bounds=(lower_bounds, upper_bounds),
         max_nfev=stopping_max_criterion_evaluations,
-        ftol=convergence_relative_criterion_tolerance,
-        gtol=convergence_relative_gradient_tolerance,
+        ftol=convergence_relative_criterion_tol,
+        gtol=convergence_relative_gradient_tol,
         method=method,
         diff_step=relative_step_size_diff_approx,
         tr_solver=tr_solver,
@@ -1014,6 +1014,62 @@ def scipy_least_squares(
     )
 
     return _process_scipy_result(res)
+
+
+def scipy_ls_trf(
+    criterion_and_derivative,
+    x,
+    lower_bounds,
+    upper_bounds,
+    *,
+    convergence_relative_criterion_tol=CONVERGENCE_RELATIVE_CRITERION_TOLERANCE,
+    convergence_relative_gradient_tol=CONVERGENCE_RELATIVE_GRADIENT_TOLERANCE,
+    stopping_max_criterion_evaluations=STOPPING_MAX_CRITERION_EVALUATIONS,
+    relative_step_size_diff_approx=None,
+    tr_solver=None,
+    tr_solver_options=None,
+):
+    return _scipy_least_squares(
+        criterion_and_derivative,
+        x,
+        lower_bounds,
+        upper_bounds,
+        convergence_relative_criterion_tol=convergence_relative_criterion_tol,
+        convergence_relative_gradient_tol=convergence_relative_gradient_tol,
+        stopping_max_criterion_evaluations=stopping_max_criterion_evaluations,
+        relative_step_size_diff_approx=relative_step_size_diff_approx,
+        tr_solver=tr_solver,
+        tr_solver_options=tr_solver_options,
+        method="trf",
+    )
+
+
+def scipy_ls_dogbox(
+    criterion_and_derivative,
+    x,
+    lower_bounds,
+    upper_bounds,
+    *,
+    convergence_relative_criterion_tol=CONVERGENCE_RELATIVE_CRITERION_TOLERANCE,
+    convergence_relative_gradient_tol=CONVERGENCE_RELATIVE_GRADIENT_TOLERANCE,
+    stopping_max_criterion_evaluations=STOPPING_MAX_CRITERION_EVALUATIONS,
+    relative_step_size_diff_approx=None,
+    tr_solver=None,
+    tr_solver_options=None,
+):
+    return _scipy_least_squares(
+        criterion_and_derivative,
+        x,
+        lower_bounds,
+        upper_bounds,
+        convergence_relative_criterion_tol=convergence_relative_criterion_tol,
+        convergence_relative_gradient_tol=convergence_relative_gradient_tol,
+        stopping_max_criterion_evaluations=stopping_max_criterion_evaluations,
+        relative_step_size_diff_approx=relative_step_size_diff_approx,
+        tr_solver=tr_solver,
+        tr_solver_options=tr_solver_options,
+        method="dogbox",
+    )
 
 
 def _process_scipy_result(scipy_results_obj):

--- a/estimagic/optimization/scipy_optimizers.py
+++ b/estimagic/optimization/scipy_optimizers.py
@@ -1035,6 +1035,12 @@ def scipy_ls_trf(
     to estimagic's maximize or minimize function as `algorithm` argument.
     Specify your desired arguments as a dictionary and pass them as `algo_options`
     to minimize or maximize.
+    
+    The algorithm iteratively solves trust-region subproblems augmented by a special
+    diagonal quadratic term and with trust-region shape determined by the distance
+    from the bounds and the direction of the gradient. This enhancements help to
+    avoid making steps directly into bounds and efficiently explore the whole space
+    of variables.
 
     This function differs from scipy_ls_dogbox because it is more 'robust' in
     bounded and unbounded problems, but can be potentially outperformed especially
@@ -1114,11 +1120,16 @@ def scipy_ls_dogbox(
     to estimagic's maximize or minimize function as `algorithm` argument.
     Specify your desired arguments as a dictionary and pass them as `algo_options`
     to minimize or maximize.
+    
+    It operates in a trust-region framework, but considers rectangular trust regions
+    as opposed to conventional ellipsoids. The intersection of a current trust
+    region and initial bounds is again rectangular, so on each iteration a quadratic
+    minimization problem subject to bound constraints is solved approximately by
+    Powell’s dogleg method.
 
     This function differs from scipy_ls_dogbox because it is not as 'robust', more
     efficient for bounded problems with a small number of variables, but exhibits
     slow convergence when the rank of Jacobian is less than the number of variables.
-
 
     Below, only details of the optional algorithm options are listed. For the mandatory
     arguments see :ref:`internal_optimizer_interface`. For more background on those

--- a/estimagic/optimization/scipy_optimizers.py
+++ b/estimagic/optimization/scipy_optimizers.py
@@ -971,7 +971,7 @@ def _scipy_least_squares(
     method="trf",
 ):
     """
-    Internal function used by the scipy_ls_ functions.
+    Internal function used by the scipy_ls_trf and scipy_ls_dogbox functions.
     Returns:
         dict: See :ref:`internal_optimizer_output` for details.
 
@@ -1035,11 +1035,11 @@ def scipy_ls_trf(
     to estimagic's maximize or minimize function as `algorithm` argument.
     Specify your desired arguments as a dictionary and pass them as `algo_options`
     to minimize or maximize.
-    
+
     The algorithm iteratively solves trust-region subproblems augmented by a special
     diagonal quadratic term and with trust-region shape determined by the distance
-    from the bounds and the direction of the gradient. This enhancements help to
-    avoid making steps directly into bounds and efficiently explore the whole space
+    from the bounds and the direction of the gradient. These enhancements help to
+    avoid making steps directly into the bounds and efficiently explore the whole space
     of variables.
 
     This function differs from scipy_ls_dogbox because it is more 'robust' in
@@ -1120,7 +1120,8 @@ def scipy_ls_dogbox(
     to estimagic's maximize or minimize function as `algorithm` argument.
     Specify your desired arguments as a dictionary and pass them as `algo_options`
     to minimize or maximize.
-    
+
+
     It operates in a trust-region framework, but considers rectangular trust regions
     as opposed to conventional ellipsoids. The intersection of a current trust
     region and initial bounds is again rectangular, so on each iteration a quadratic

--- a/estimagic/optimization/scipy_optimizers.py
+++ b/estimagic/optimization/scipy_optimizers.py
@@ -971,8 +971,7 @@ def _scipy_least_squares(
     method="trf",
 ):
     """
-    Add Documentation.
-
+    Internal function used by the scipy_ls_ functions.
     Returns:
         dict: See :ref:`internal_optimizer_output` for details.
 
@@ -1029,6 +1028,57 @@ def scipy_ls_trf(
     tr_solver=None,
     tr_solver_options=None,
 ):
+    """
+    Minimize a scalar function using a trust region reflective method.
+
+    Do not call this function directly but pass its name "scipy_truncated_newton"
+    to estimagic's maximize or minimize function as `algorithm` argument.
+    Specify your desired arguments as a dictionary and pass them as `algo_options`
+    to minimize or maximize.
+
+    This function differs from scipy_ls_dogbox because it is more 'robust' in
+    bounded and unbounded problems, but can be potentially outperformed especially
+    in bounded problems with a small number of variables.
+
+    Below, only details of the optional algorithm options are listed. For the mandatory
+    arguments see :ref:`internal_optimizer_interface`. For more background on those
+    options, see :ref:`naming_conventions`.
+
+    Args:
+        convergence_relative_criterion_tol (float): Stop when the relative improvement
+                between two iterations is below this.
+        convergence_relative_gradient_tol (float): Stop when the gradient, divided
+            by the absolute value of the criterion function is smaller than this.
+        stopping_max_criterion_evaluations (int): If the maximum number of function
+            evaluation is reached, the optimization stops but we do not count this as
+            convergence.
+        relative_step_size_diff_approx (array_like): Determines the relative step size
+            for the finite difference approximation of the Jacobian. The actual
+            step is computed as `x * diff_step`.
+        tr_solver (str): Method for solving trust-region subproblems, relevant only
+            for 'trf' and 'dogbox' methods.
+            * 'exact' is suitable for not very large problems with dense
+              Jacobian matrices. The computational complexity per iteration is
+              comparable to a singular value decomposition of the Jacobian
+              matrix.
+            * 'lsmr' is suitable for problems with sparse and large Jacobian
+              matrices. It uses the iterative procedure
+              `scipy.sparse.linalg.lsmr` for finding a solution of a linear
+              least-squares problem and only requires matrix-vector product
+              evaluations.
+            If None (default), the solver is chosen based on the type of Jacobian
+            returned on the first iteration.
+        tr_solver_options (dict):  Keyword options passed to trust-region solver.
+            * ``tr_solver='exact'``: `tr_options` are ignored.
+            * ``tr_solver='lsmr'``: options for `scipy.sparse.linalg.lsmr`.
+              Additionally,  supports  'regularize' option
+              (bool, default is True), which adds a regularization term to the
+              normal equation, which improves convergence if the Jacobian is
+              rank-deficient.
+
+    Returns:
+        dict: See :ref:`internal_optimizer_output` for details.
+    """
     return _scipy_least_squares(
         criterion_and_derivative,
         x,
@@ -1057,6 +1107,54 @@ def scipy_ls_dogbox(
     tr_solver=None,
     tr_solver_options=None,
 ):
+    """
+    Minimize a scalar function using a rectangular trust region method.
+
+    Do not call this function directly but pass its name "scipy_truncated_newton"
+    to estimagic's maximize or minimize function as `algorithm` argument.
+    Specify your desired arguments as a dictionary and pass them as `algo_options`
+    to minimize or maximize.
+
+    This function differs from scipy_ls_dogbox because it is not as 'robust', more
+    efficient for bounded problems with a small number of variables, but exhibits
+    slow convergence when the rank of Jacobian is less than the number of variables.
+
+
+    Below, only details of the optional algorithm options are listed. For the mandatory
+    arguments see :ref:`internal_optimizer_interface`. For more background on those
+    options, see :ref:`naming_conventions`.
+
+    Args:
+        convergence_relative_criterion_tol (float): Stop when the relative improvement
+                between two iterations is below this.
+        convergence_relative_gradient_tol (float): Stop when the gradient, divided
+            by the absolute value of the criterion function is smaller than this.
+        stopping_max_criterion_evaluations (int): If the maximum number of function
+            evaluation is reached, the optimization stops but we do not count this as
+            convergence.
+        relative_step_size_diff_approx (array_like): Determines the relative step size
+            for the finite difference approximation of the Jacobian. The actual
+            step is computed as `x * diff_step`.
+        tr_solver (str): Method for solving trust-region subproblems, relevant only
+            for 'trf' and 'dogbox' methods.
+            * 'exact' is suitable for not very large problems with dense
+              Jacobian matrices. The computational complexity per iteration is
+              comparable to a singular value decomposition of the Jacobian
+              matrix.
+            * 'lsmr' is suitable for problems with sparse and large Jacobian
+              matrices. It uses the iterative procedure
+              `scipy.sparse.linalg.lsmr` for finding a solution of a linear
+              least-squares problem and only requires matrix-vector product
+              evaluations.
+            If None (default), the solver is chosen based on the type of Jacobian
+            returned on the first iteration.
+        tr_solver_options (dict):  Keyword options passed to trust-region solver.
+            * ``tr_solver='exact'``: `tr_options` are ignored.
+            * ``tr_solver='lsmr'``: options for `scipy.sparse.linalg.lsmr`.
+
+    Returns:
+        dict: See :ref:`internal_optimizer_output` for details.
+    """
     return _scipy_least_squares(
         criterion_and_derivative,
         x,

--- a/estimagic/optimization/scipy_optimizers.py
+++ b/estimagic/optimization/scipy_optimizers.py
@@ -966,6 +966,8 @@ def scipy_least_squares(
     convergence_relative_gradient_tolerance=CONVERGENCE_RELATIVE_GRADIENT_TOLERANCE,
     stopping_max_criterion_evaluations=STOPPING_MAX_CRITERION_EVALUATIONS,
     relative_step_size_diff_approx=None,
+    tr_solver=None,
+    tr_solver_options=None,
     method="trf",
 ):
     """
@@ -980,6 +982,9 @@ def scipy_least_squares(
         raise ValueError(
             f"Method {method} is not supported within scipy_least_squares."
         )
+
+    if tr_solver_options is None:
+        tr_solver_options = {}
 
     algo_info = DEFAULT_ALGO_INFO.copy()
     algo_info["name"] = "scipy_least_squares"
@@ -1004,6 +1009,8 @@ def scipy_least_squares(
         gtol=convergence_relative_gradient_tolerance,
         method=method,
         diff_step=relative_step_size_diff_approx,
+        tr_solver=tr_solver,
+        tr_options=tr_solver_options,
     )
 
     return _process_scipy_result(res)

--- a/estimagic/optimization/scipy_optimizers.py
+++ b/estimagic/optimization/scipy_optimizers.py
@@ -44,10 +44,10 @@ import numpy as np
 import scipy
 
 from estimagic.optimization.algo_options import CONVERGENCE_ABSOLUTE_CRITERION_TOLERANCE
-from estimagic.optimization.algo_options import CONVERGENCE_RELATIVE_GRADIENT_TOLERANCE
 from estimagic.optimization.algo_options import CONVERGENCE_ABSOLUTE_GRADIENT_TOLERANCE
 from estimagic.optimization.algo_options import CONVERGENCE_ABSOLUTE_PARAMS_TOLERANCE
 from estimagic.optimization.algo_options import CONVERGENCE_RELATIVE_CRITERION_TOLERANCE
+from estimagic.optimization.algo_options import CONVERGENCE_RELATIVE_GRADIENT_TOLERANCE
 from estimagic.optimization.algo_options import CONVERGENCE_RELATIVE_PARAMS_TOLERANCE
 from estimagic.optimization.algo_options import (
     CONVERGENCE_SECOND_BEST_ABSOLUTE_CRITERION_TOLERANCE,
@@ -966,10 +966,10 @@ def scipy_least_squares(
     convergence_relative_gradient_tolerance=CONVERGENCE_RELATIVE_GRADIENT_TOLERANCE,
     stopping_max_criterion_evaluations=STOPPING_MAX_CRITERION_EVALUATIONS,
     relative_step_size_diff_approx=None,
-    method="trf"
+    method="trf",
 ):
     """
-    TODO: Add Documentation.
+    Add Documentation.
 
     Returns:
         dict: See :ref:`internal_optimizer_output` for details.
@@ -977,7 +977,9 @@ def scipy_least_squares(
     """
 
     if method not in ["trf", "dogbox", "lm"]:
-        raise ValueError(f"Method {method} is not supported within scipy_least_squares.")
+        raise ValueError(
+            f"Method {method} is not supported within scipy_least_squares."
+        )
 
     algo_info = DEFAULT_ALGO_INFO.copy()
     algo_info["name"] = "scipy_least_squares"

--- a/estimagic/optimization/tao_optimizers.py
+++ b/estimagic/optimization/tao_optimizers.py
@@ -43,7 +43,7 @@ def tao_pounders(
     maximize.
 
     POUNDERs (:cite:`Benson2017`, :cite:`Wild2015`, `GitLab repository
-    <https://gitlab.com/petsc/petsc/-/tree/master/src/binding/petsc4py/>`_)
+    <https://gitlab.com/petsc/petsc4py/-/tree/master>`_)
     can be a useful tool for economists who estimate structural models using
     indirect inference, because unlike commonly used algorithms such as Nelder-Mead,
     POUNDERs is tailored for minimizing a non-linear sum of squares objective function,

--- a/estimagic/tests/optimization/test_all_algorithms_with_sum_of_squares.py
+++ b/estimagic/tests/optimization/test_all_algorithms_with_sum_of_squares.py
@@ -32,7 +32,12 @@ BOUNDS_SUPPORTING_ALGORITHMS = [
     alg for alg in AVAILABLE_ALGORITHMS if alg not in BOUNDS_FREE_ALGORITHMS
 ]
 
-IMPRECISE_ALGOS = ["scipy_powell", "scipy_truncated_newton", "scipy_trust_constr", "scipy_least_squares"]
+IMPRECISE_ALGOS = [
+    "scipy_powell",
+    "scipy_truncated_newton",
+    "scipy_trust_constr",
+    "scipy_least_squares",
+]
 
 
 def _skip_tests_with_missing_dependencies(test_cases):

--- a/estimagic/tests/optimization/test_all_algorithms_with_sum_of_squares.py
+++ b/estimagic/tests/optimization/test_all_algorithms_with_sum_of_squares.py
@@ -36,7 +36,8 @@ IMPRECISE_ALGOS = [
     "scipy_powell",
     "scipy_truncated_newton",
     "scipy_trust_constr",
-    "scipy_least_squares",
+    "scipy_ls_trf",
+    "scipy_ls_dogbox",
 ]
 
 
@@ -123,7 +124,12 @@ def sos_criterion_and_jacobian(params):
 
 def get_test_cases_for_algorithm(algorithm):
     """Generate list of all possible argument combinations for algorithm."""
-    is_least_squares = algorithm in ["tao_pounders", "nag_dfols", "scipy_least_squares"]
+    is_least_squares = algorithm in [
+        "tao_pounders",
+        "nag_dfols",
+        "scipy_ls_trf",
+        "scipy_ls_dogbox",
+    ]
     is_sum = algorithm in ["bhhh"]
     is_scalar = not (is_least_squares or is_sum)
 

--- a/estimagic/tests/optimization/test_all_algorithms_with_sum_of_squares.py
+++ b/estimagic/tests/optimization/test_all_algorithms_with_sum_of_squares.py
@@ -19,19 +19,22 @@ from estimagic.optimization import AVAILABLE_ALGORITHMS
 from estimagic.optimization.optimize import maximize
 from estimagic.optimization.optimize import minimize
 
+
 BOUNDS_FREE_ALGORITHMS = [
     "scipy_neldermead",
     "scipy_conjugate_gradient",
     "scipy_bfgs",
     "scipy_newton_cg",
     "scipy_cobyla",
+    # TODO: Remove least_squares. It supports bounds but not constraints.
+    "scipy_least_squares"
 ]
 
 BOUNDS_SUPPORTING_ALGORITHMS = [
     alg for alg in AVAILABLE_ALGORITHMS if alg not in BOUNDS_FREE_ALGORITHMS
 ]
 
-IMPRECISE_ALGOS = ["scipy_powell", "scipy_truncated_newton", "scipy_trust_constr"]
+IMPRECISE_ALGOS = ["scipy_powell", "scipy_truncated_newton", "scipy_trust_constr", "scipy_least_squares"]
 
 
 def _skip_tests_with_missing_dependencies(test_cases):
@@ -117,7 +120,7 @@ def sos_criterion_and_jacobian(params):
 
 def get_test_cases_for_algorithm(algorithm):
     """Generate list of all possible argument combinations for algorithm."""
-    is_least_squares = algorithm in ["tao_pounders", "nag_dfols"]
+    is_least_squares = algorithm in ["tao_pounders", "nag_dfols", "scipy_least_squares"]
     is_sum = algorithm in ["bhhh"]
     is_scalar = not (is_least_squares or is_sum)
 

--- a/estimagic/tests/optimization/test_all_algorithms_with_sum_of_squares.py
+++ b/estimagic/tests/optimization/test_all_algorithms_with_sum_of_squares.py
@@ -26,8 +26,6 @@ BOUNDS_FREE_ALGORITHMS = [
     "scipy_bfgs",
     "scipy_newton_cg",
     "scipy_cobyla",
-    # TODO: Remove least_squares. It supports bounds but not constraints.
-    "scipy_least_squares"
 ]
 
 BOUNDS_SUPPORTING_ALGORITHMS = [


### PR DESCRIPTION
This fork includes `scipy.optimize.least_squares` with two flavors, `trf` and `dogbox`, into estimagic's collection of internal optimizers.

An additional repository with explanatory notebook can be found [here](https://github.com/yradeva93/Estimagic-Least-Squares-Example). It includes my OSE project submission under the tag `submission`.

Almost all modifications were done in the file `estimagic/optimization/scipy_optimizers.py`. Adding the optimizers was done in the following steps:
1. Add a function `scipy_least_squares`, with the different algorithms (`trf` and `dogbox`) as parameters. Later this API was changed (see below).
2. Add the function to the test suite, by marking it as imprecise (i.e. adding it to `IMPRECISE_ALGOS` and `is_least_sqaures lists`).
3. Add relevant parameters to the function and supply them to the underlying `scipy_least_squares` function.
4. Wonder for multiple hours, why tox throws errors. Find out that it is because `petsc` Gitlab link was broken.
5. Fix the `petsc` link in the documentation.
6. Change the API to one internal function `_scipy_least_squares` and two front facing functions `scipy_ls_trf` and `scipy_ls_dogbox`. This was done to better fit into the estimagic internal structure.
7. Remove support for the `lm` (Levenberg-Marquardt) method as it is not compatible with the estimagic API.
8. Align tests to points 6. and 7.
9. Write documentation.