### PR TITLE
Switch to Fides >= 0.7.1

### DIFF
--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -45,4 +45,4 @@ To enable all algorithms at once, do the following:
 
 ``conda install pygmo``
 
-``pip install fides>=0.6.3`` (Make sure you have at least 0.6.3)
+``pip install fides>=0.7.1`` (Make sure you have at least 0.7.1)

--- a/docs/source/how_to_guides/optimization/how_to_specify_algorithm_and_algo_options.rst
+++ b/docs/source/how_to_guides/optimization/how_to_specify_algorithm_and_algo_options.rst
@@ -2680,7 +2680,7 @@ The Fides Optimizer
 estimagic supports the `Fides Optimizer
 <https://fides-optimizer.readthedocs.io/en/latest>`_. To use Fides, you need to have
 `the fides package <https://github.com/fides-dev/fides>`_ installed (``pip install
-fides>=0.6.3``, make sure you have at least version 0.6.3).
+fides>=0.7.1``, make sure you have at least version 0.7.1).
 
 
 .. warning::

--- a/environment.yml
+++ b/environment.yml
@@ -52,6 +52,6 @@ dependencies:
       - pre-commit
       - Py-BOBYQA
       - DFO-LS
-      - fides==0.6.3
+      - fides>=0.7.1
       - gif
       - gif[matplotlib]

--- a/src/estimagic/optimization/fides_optimizers.py
+++ b/src/estimagic/optimization/fides_optimizers.py
@@ -47,7 +47,7 @@ def fides(
     if not IS_FIDES_INSTALLED:
         raise NotImplementedError(
             "The fides package is not installed. You can install it with "
-            "`pip install fides>=0.6.3`."
+            "`pip install fides>=0.7.1`."
         )
 
     fides_options = {

--- a/src/estimagic/optimization/fides_optimizers.py
+++ b/src/estimagic/optimization/fides_optimizers.py
@@ -38,8 +38,6 @@ def fides(
     trustregion_increase_threshold=0.75,
     trustregion_decrease_factor=0.25,
     trustregion_increase_factor=2.0,
-    trustregion_refine_stepback=False,
-    trustregion_scaled_gradient_as_possible_stepback=False,
 ):
     """Minimize a scalar function using the Fides Optimizer.
 
@@ -53,23 +51,22 @@ def fides(
         )
 
     fides_options = {
+        "delta_init": trustregion_initial_radius,
+        "eta": trustregion_increase_threshold,
         "fatol": convergence_absolute_criterion_tolerance,
         "frtol": convergence_relative_criterion_tolerance,
-        "xtol": convergence_absolute_params_tolerance,
+        "gamma1": trustregion_decrease_factor,
+        "gamma2": trustregion_increase_factor,
         "gatol": convergence_absolute_gradient_tolerance,
         "grtol": convergence_relative_gradient_tolerance,
+        "history_file": None,
         "maxiter": stopping_max_iterations,
-        "delta_init": trustregion_initial_radius,
         "maxtime": stopping_max_seconds,
+        "mu": trustregion_decrease_threshold,
         "stepback_strategy": trustregion_stepback_strategy,
         "subspace_solver": trustregion_subspace_dimension,
         "theta_max": trustregion_max_stepback_fraction,
-        "mu": trustregion_decrease_threshold,
-        "eta": trustregion_increase_threshold,
-        "gamma1": trustregion_decrease_factor,
-        "gamma2": trustregion_increase_factor,
-        "refine_stepback": trustregion_refine_stepback,
-        "scaled_gradient": trustregion_scaled_gradient_as_possible_stepback,
+        "xtol": convergence_absolute_params_tolerance,
     }
 
     algo_info = {

--- a/tests/optimization/test_fides_options.py
+++ b/tests/optimization/test_fides_options.py
@@ -38,10 +38,6 @@ test_cases_no_contribs_needed = [
     {"trustregion_max_stepback_fraction": 0.8},
     {"trustregion_decrease_threshold": 0.4, "trustregion_decrease_factor": 0.2},
     {"trustregion_increase_threshold": 0.9, "trustregion_increase_factor": 4},
-    {
-        "trustregion_refine_stepback": True,
-        "trustregion_scaled_gradient_as_possible_stepback": True,
-    },
 ]
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ conda_channels =
 deps =
     Py-BOBYQA
     DFO-LS
-    fides == 0.6.3
+    fides == 0.7.1
 conda_deps =
     bokeh >= 1.3
     click


### PR DESCRIPTION
I have adjusted the interface and the tests for the latest Fides version. 

The RuntimeWarnings when some parameters are unbounded still persist. I opened [a Fides Issue](https://github.com/fides-dev/fides/issues/46) for this. 