### PR TITLE
New internal-optimizer-interface

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Continuous Integration Workflow
+name: main
 
 # Automatically cancel a previous run.
 concurrency:

--- a/docs/source/how_to_guides/optimization/how_to_specify_algorithm_and_algo_options.rst
+++ b/docs/source/how_to_guides/optimization/how_to_specify_algorithm_and_algo_options.rst
@@ -437,6 +437,9 @@ dependencies to use them:
 
     Minimize a nonlinear least squares problem using a rectangular trust region method.
 
+    Typical use case is small problems with bounds. Not recommended for problems with
+    rank-deficient Jacobian.
+
     The algorithm supports the following options:
 
     - **convergence.relative_criterion_tolerance** (float): Stop when the relative
@@ -469,6 +472,45 @@ dependencies to use them:
 .. dropdown::  scipy_ls_trf
 
     Minimize a nonlinear least squares problem using a trustregion reflective method.
+
+    Trust Region Reflective algorithm, particularly suitable for large sparse problems
+    with bounds. Generally robust method.
+
+    The algorithm supports the following options:
+
+    - **convergence.relative_criterion_tolerance** (float): Stop when the relative
+      improvement between two iterations is below this.
+    - **convergence.relative_gradient_tolerance** (float): Stop when the gradient,
+      divided by the absolute value of the criterion function is smaller than this.
+    - **stopping.max_criterion_evaluations** (int): If the maximum number of function
+      evaluation is reached, the optimization stops but we do not count this as
+      convergence.
+    - **tr_solver** (str): Method for solving trust-region subproblems, relevant only
+      for 'trf' and 'dogbox' methods.
+
+      - 'exact' is suitable for not very large problems with dense
+        Jacobian matrices. The computational complexity per iteration is
+        comparable to a singular value decomposition of the Jacobian
+        matrix.
+      - 'lsmr' is suitable for problems with sparse and large Jacobian
+        matrices. It uses the iterative procedure
+        `scipy.sparse.linalg.lsmr` for finding a solution of a linear
+        least-squares problem and only requires matrix-vector product
+        evaluations.
+        If None (default), the solver is chosen based on the type of Jacobian
+        returned on the first iteration.
+    - **tr_solver_options** (dict):  Keyword options passed to trust-region solver.
+
+      - ``tr_solver='exact'``: `tr_options` are ignored.
+      - ``tr_solver='lsmr'``: options for `scipy.sparse.linalg.lsmr`.
+
+
+.. dropdown::  scipy_ls_lm
+
+    Minimize a nonlinear least squares problem using a Levenberg-Marquardt method.
+
+    Does not handle bounds and sparse Jacobians. Usually the most efficient method for
+    small unconstrained problems.
 
     The algorithm supports the following options:
 

--- a/src/estimagic/optimization/__init__.py
+++ b/src/estimagic/optimization/__init__.py
@@ -1,72 +1,39 @@
 import inspect
 
-from estimagic.config import IS_CYIPOPT_INSTALLED
-from estimagic.config import IS_DFOLS_INSTALLED
-from estimagic.config import IS_FIDES_INSTALLED
-from estimagic.config import IS_NLOPT_INSTALLED
-from estimagic.config import IS_PETSC4PY_INSTALLED
-from estimagic.config import IS_PYBOBYQA_INSTALLED
-from estimagic.config import IS_PYGMO_INSTALLED
+from estimagic.optimization import bhhh
 from estimagic.optimization import cyipopt_optimizers
 from estimagic.optimization import fides_optimizers
 from estimagic.optimization import nag_optimizers
+from estimagic.optimization import neldermead
 from estimagic.optimization import nlopt_optimizers
+from estimagic.optimization import pounders
 from estimagic.optimization import pygmo_optimizers
 from estimagic.optimization import scipy_optimizers
 from estimagic.optimization import tao_optimizers
-from estimagic.optimization.bhhh import bhhh
-from estimagic.optimization.neldermead import neldermead_parallel
-from estimagic.optimization.pounders import pounders
 
 
-COLLECTED_FUNCTIONS = {
-    **dict(inspect.getmembers(scipy_optimizers, inspect.isfunction)),
-}
-
-if IS_PETSC4PY_INSTALLED:
-    COLLECTED_FUNCTIONS.update(
-        **dict(inspect.getmembers(tao_optimizers, inspect.isfunction))
-    )
-
-if IS_NLOPT_INSTALLED:
-    COLLECTED_FUNCTIONS.update(
-        **dict(inspect.getmembers(nlopt_optimizers, inspect.isfunction))
-    )
-
-# drop private and helper functions
-AVAILABLE_ALGORITHMS = {
-    "bhhh": bhhh,
-    "neldermead_parallel": neldermead_parallel,
-    "pounders": pounders,
-}
-
-PUBLIC_HELPERS = [
-    "calculate_trustregion_initial_radius",
-    "get_scipy_bounds",
-    "process_scipy_result",
+MODULES = [
+    cyipopt_optimizers,
+    fides_optimizers,
+    nag_optimizers,
+    nlopt_optimizers,
+    pygmo_optimizers,
+    scipy_optimizers,
+    tao_optimizers,
+    bhhh,
+    neldermead,
+    pounders,
 ]
-for k, v in COLLECTED_FUNCTIONS.items():
-    if not k.startswith("_") and k not in PUBLIC_HELPERS:
-        AVAILABLE_ALGORITHMS[k] = v
 
-if IS_PYBOBYQA_INSTALLED:
-    AVAILABLE_ALGORITHMS["nag_pybobyqa"] = nag_optimizers.nag_pybobyqa
 
-if IS_DFOLS_INSTALLED:
-    AVAILABLE_ALGORITHMS["nag_dfols"] = nag_optimizers.nag_dfols
+AVAILABLE_ALGORITHMS = {}
+for module in MODULES:
+    func_dict = dict(inspect.getmembers(module, inspect.isfunction))
+    for name, func in func_dict.items():
+        if hasattr(func, "_algorithm_info"):
+            if func._algorithm_info.is_available:
+                AVAILABLE_ALGORITHMS[name] = func
 
-if IS_PYGMO_INSTALLED:
-    _PYGMO_FUNCTIONS = dict(inspect.getmembers(pygmo_optimizers, inspect.isfunction))
-    PYGMO_ALGORITHMS = {
-        k: v for k, v in _PYGMO_FUNCTIONS.items() if k.startswith("pygmo_")
-    }
-    AVAILABLE_ALGORITHMS.update(**PYGMO_ALGORITHMS)
-
-if IS_CYIPOPT_INSTALLED:
-    AVAILABLE_ALGORITHMS["ipopt"] = cyipopt_optimizers.ipopt
-
-if IS_FIDES_INSTALLED:
-    AVAILABLE_ALGORITHMS["fides"] = fides_optimizers.fides
 
 GLOBAL_ALGORITHMS = [
     "nlopt_direct",
@@ -74,5 +41,5 @@ GLOBAL_ALGORITHMS = [
     "nlopt_isres",
     "nlopt_crs2_lm",
 ]
-if IS_PYGMO_INSTALLED:
-    GLOBAL_ALGORITHMS += PYGMO_ALGORITHMS.keys()
+
+GLOBAL_ALGORITHMS += [name for name in AVAILABLE_ALGORITHMS if name.startswith("pygmo")]

--- a/src/estimagic/optimization/__init__.py
+++ b/src/estimagic/optimization/__init__.py
@@ -25,12 +25,13 @@ MODULES = [
     pounders,
 ]
 
-
+ALL_ALGORITHMS = {}
 AVAILABLE_ALGORITHMS = {}
 for module in MODULES:
     func_dict = dict(inspect.getmembers(module, inspect.isfunction))
     for name, func in func_dict.items():
         if hasattr(func, "_algorithm_info"):
+            ALL_ALGORITHMS[name] = func
             if func._algorithm_info.is_available:
                 AVAILABLE_ALGORITHMS[name] = func
 

--- a/src/estimagic/optimization/bhhh.py
+++ b/src/estimagic/optimization/bhhh.py
@@ -5,7 +5,7 @@ from estimagic.decorators import mark_minimizer
 
 @mark_minimizer(
     name="bhhh",
-    primary_criterion_entry="root_contributions",
+    primary_criterion_entry="contributions",
     parallelizes=False,
     needs_scaling=False,
     disable_cache=False,

--- a/src/estimagic/optimization/bhhh.py
+++ b/src/estimagic/optimization/bhhh.py
@@ -1,12 +1,20 @@
 """Implement Berndt-Hall-Hall-Hausman (BHHH) algorithm."""
-from functools import partial
-
 import numpy as np
+from estimagic.decorators import mark_minimizer
 
 
+@mark_minimizer(
+    name="bhhh",
+    primary_criterion_entry="root_contributions",
+    parallelizes=False,
+    needs_scaling=False,
+    disable_cache=False,
+    is_available=True,
+)
 def bhhh(
     criterion_and_derivative,
     x,
+    *,
     convergence_absolute_gradient_tolerance=1e-8,
     stopping_max_iterations=200,
 ):
@@ -14,18 +22,8 @@ def bhhh(
 
     For details, see :ref:`_own_algorithms`.
     """
-    algorithm_info = {
-        "primary_criterion_entry": "root_contributions",
-        "parallelizes": False,
-        "needs_scaling": False,
-        "name": "bhhh",
-    }
-    _criterion_and_derivative = partial(
-        criterion_and_derivative, algorithm_info=algorithm_info
-    )
-
     result_dict = bhhh_internal(
-        criterion_and_derivative=_criterion_and_derivative,
+        criterion_and_derivative,
         x=x,
         convergence_absolute_gradient_tolerance=convergence_absolute_gradient_tolerance,
         stopping_max_iterations=stopping_max_iterations,
@@ -59,9 +57,7 @@ def bhhh_internal(
             solution vector or reaching stopping_max_iterations.
         - message (str): Message to the user. Currently it says: "Under development."
     """
-    criterion_accepted, gradient = criterion_and_derivative(
-        x, task="criterion_and_derivative"
-    )
+    criterion_accepted, gradient = criterion_and_derivative(x)
     x_accepted = x
 
     hessian_approx = np.dot(gradient.T, gradient)
@@ -77,17 +73,14 @@ def bhhh_internal(
         niter += 1
 
         x_candidate = x_accepted + step_size * direction
-        criterion_candidate = criterion_and_derivative(x_candidate, task="criterion")
+        criterion_candidate, gradient = criterion_and_derivative(x_candidate)
 
         # If previous step was accepted
         if step_size == initial_step_size:
-            gradient = criterion_and_derivative(x_candidate, task="derivative")
             hessian_approx = np.dot(gradient.T, gradient)
 
         else:
-            criterion_candidate, gradient = criterion_and_derivative(
-                x_candidate, task="criterion_and_derivative"
-            )
+            criterion_candidate, gradient = criterion_and_derivative(x_candidate)
 
         # Line search
         if np.sum(criterion_candidate) > np.sum(criterion_accepted):

--- a/src/estimagic/optimization/cyipopt_optimizers.py
+++ b/src/estimagic/optimization/cyipopt_optimizers.py
@@ -2,6 +2,7 @@
 import functools
 
 from estimagic.config import IS_CYIPOPT_INSTALLED
+from estimagic.exceptions import NotInstalledError
 from estimagic.optimization.algo_options import CONVERGENCE_RELATIVE_CRITERION_TOLERANCE
 from estimagic.optimization.algo_options import STOPPING_MAX_ITERATIONS
 from estimagic.optimization.scipy_optimizers import get_scipy_bounds
@@ -209,9 +210,9 @@ def ipopt(
 
     """
     if not IS_CYIPOPT_INSTALLED:
-        raise NotImplementedError(
-            "The cyipopt package is not installed and required for 'ipopt'. You can "
-            "install the package with: `conda install -c conda-forge cyipopt`"
+        raise NotInstalledError(
+            "The 'ipopt' algorithm requires the cyipopt package to be installed. "
+            "You can it with: `conda install -c conda-forge cyipopt`."
         )
     if acceptable_tol <= convergence_relative_criterion_tolerance:
         raise ValueError(

--- a/src/estimagic/optimization/fides_optimizers.py
+++ b/src/estimagic/optimization/fides_optimizers.py
@@ -4,6 +4,7 @@ from functools import partial
 
 import numpy as np
 from estimagic.config import IS_FIDES_INSTALLED
+from estimagic.exceptions import NotInstalledError
 from estimagic.optimization.algo_options import CONVERGENCE_ABSOLUTE_CRITERION_TOLERANCE
 from estimagic.optimization.algo_options import CONVERGENCE_ABSOLUTE_GRADIENT_TOLERANCE
 from estimagic.optimization.algo_options import CONVERGENCE_ABSOLUTE_PARAMS_TOLERANCE
@@ -45,9 +46,9 @@ def fides(
 
     """
     if not IS_FIDES_INSTALLED:
-        raise NotImplementedError(
-            "The fides package is not installed. You can install it with "
-            "`pip install fides>=0.7.4`."
+        raise NotInstalledError(
+            "The 'fides' algorithm requires the fides package to be installed. "
+            "You can install it with `pip install fides>=0.7.4`."
         )
 
     fides_options = {

--- a/src/estimagic/optimization/fides_optimizers.py
+++ b/src/estimagic/optimization/fides_optimizers.py
@@ -20,7 +20,7 @@ if IS_FIDES_INSTALLED:
 @mark_minimizer(
     name="fides",
     primary_criterion_entry="value",
-    disable_cache=True,
+    disable_cache=False,
     needs_scaling=False,
     parallelizes=False,
     is_available=IS_FIDES_INSTALLED,

--- a/src/estimagic/optimization/fides_optimizers.py
+++ b/src/estimagic/optimization/fides_optimizers.py
@@ -1,9 +1,9 @@
 """Implement the fides optimizer."""
 import logging
-from functools import partial
 
 import numpy as np
 from estimagic.config import IS_FIDES_INSTALLED
+from estimagic.decorators import mark_minimizer
 from estimagic.exceptions import NotInstalledError
 from estimagic.optimization.algo_options import CONVERGENCE_ABSOLUTE_CRITERION_TOLERANCE
 from estimagic.optimization.algo_options import CONVERGENCE_ABSOLUTE_GRADIENT_TOLERANCE
@@ -17,6 +17,14 @@ if IS_FIDES_INSTALLED:
     from fides import Optimizer
 
 
+@mark_minimizer(
+    name="fides",
+    primary_criterion_entry="value",
+    disable_cache=True,
+    needs_scaling=False,
+    parallelizes=False,
+    is_available=IS_FIDES_INSTALLED,
+)
 def fides(
     criterion_and_derivative,
     x,
@@ -69,23 +77,10 @@ def fides(
         "xtol": convergence_absolute_params_tolerance,
     }
 
-    algo_info = {
-        "primary_criterion_entry": "value",
-        "parallelizes": False,
-        "needs_scaling": False,
-        "name": "fides",
-    }
-
-    fun = partial(
-        criterion_and_derivative,
-        task="criterion_and_derivative",
-        algorithm_info=algo_info,
-    )
-
     hessian_instance = _create_hessian_updater_from_user_input(hessian_update_strategy)
 
     opt = Optimizer(
-        fun=fun,
+        fun=criterion_and_derivative,
         lb=lower_bounds,
         ub=upper_bounds,
         verbose=logging.ERROR,

--- a/src/estimagic/optimization/internal_criterion_template.py
+++ b/src/estimagic/optimization/internal_criterion_template.py
@@ -38,7 +38,7 @@ def internal_criterion_and_derivative_template(
     params,
     reparametrize_from_internal,
     convert_derivative,
-    algorithm_info,
+    algo_info,
     derivative,
     criterion_and_derivative,
     numdiff_options,
@@ -54,8 +54,8 @@ def internal_criterion_and_derivative_template(
     """Template for the internal criterion and derivative function.
 
     The internal criterion and derivative function only has the arguments x and task
-    and algorithm_info. The other arguments will be partialed in by estimagic at some
-    point. Algorithm_info and possibly even task will be partialed in by the algorithm.
+    and algo_info. The other arguments will be partialed in by estimagic at some
+    point. algo_info and possibly even task will be partialed in by the algorithm.
 
     That is the reason why this function is called a template.
 
@@ -72,13 +72,13 @@ def internal_criterion_and_derivative_template(
         convert_derivative (callable): Function that takes the derivative of criterion
             at the external version of x and x and returns the derivative
             of the internal criterion.
-        algorithm_info (dict): Dict with the following entries:
-            "primary_criterion_entry": One of "value", "contributions" and
-                "root_contributions" or "dict".
-            "parallelizes": Bool that indicates if the algorithm calls the internal
-                criterion function in parallel. If so, caching is disabled.
-            "needs_scaling": bool
-            "name": string
+        algo_info (AlgoInfo): NamedTuple with attributes
+            - primary_criterion_entry
+            - name
+            - parallelizes
+            - disable_cache
+            - needs_scaling
+            - is_available
         derivative (callable, optional): (partialed) user provided function that
             calculates the first derivative of criterion. For most algorithm, this is
             the gradient of the scalar output (or "value" entry of the dict). However
@@ -121,13 +121,13 @@ def internal_criterion_and_derivative_template(
             If task=="criterion_and_derivative" it returns both as a tuple.
 
     """
-    if algorithm_info["primary_criterion_entry"] == "root_contributions":
+    if algo_info.primary_criterion_entry == "root_contributions":
         if direction == "maximize":
             msg = (
                 "Optimizers that exploit a least squares structure like {} can only be "
                 "used for minimization."
             )
-            raise ValueError(msg.format(algorithm_info["name"]))
+            raise ValueError(msg.format(algo_info.name))
 
     x_hash = hash_array(x)
     cache_entry = cache.get(x_hash, {})
@@ -151,14 +151,14 @@ def internal_criterion_and_derivative_template(
             return criterion(p)
 
         options = numdiff_options.copy()
-        options["key"] = algorithm_info["primary_criterion_entry"]
+        options["key"] = algo_info.primary_criterion_entry
         options["f0"] = cache_entry.get("criterion", None)
         options["return_func_value"] = True
 
         try:
             derivative_dict = first_derivative(func, x, **options)
             new_derivative = {
-                algorithm_info["primary_criterion_entry"]: derivative_dict["derivative"]
+                algo_info.primary_criterion_entry: derivative_dict["derivative"]
             }
             new_criterion = derivative_dict["func_value"]
         except (KeyboardInterrupt, SystemExit):
@@ -204,7 +204,7 @@ def internal_criterion_and_derivative_template(
     if new_derivative is None and new_external_derivative is not None:
         if not isinstance(new_external_derivative, dict):
             new_external_derivative = {
-                algorithm_info["primary_criterion_entry"]: new_external_derivative
+                algo_info.primary_criterion_entry: new_external_derivative
             }
 
         new_derivative = {
@@ -215,21 +215,21 @@ def internal_criterion_and_derivative_template(
     if caught_exceptions:
         if error_handling == "continue":
             new_criterion, new_derivative = _penalty_and_derivative(
-                x, first_criterion_evaluation, error_penalty, algorithm_info
+                x, first_criterion_evaluation, error_penalty, algo_info
             )
             warnings.warn("\n\n".join(caught_exceptions))
         else:
             raise Exception("\n\n".join(caught_exceptions))
 
-    if not algorithm_info["parallelizes"] and cache_size >= 1:
+    if not (algo_info.parallelizes or algo_info.disable_cache) and cache_size >= 1:
         _cache_new_evaluations(new_criterion, new_derivative, x_hash, cache, cache_size)
 
     new_criterion = _check_and_harmonize_criterion_output(
-        cache_entry.get("criterion", new_criterion), algorithm_info
+        cache_entry.get("criterion", new_criterion), algo_info
     )
 
     new_derivative = _check_and_harmonize_derivative(
-        cache_entry.get("derivative", new_derivative), algorithm_info
+        cache_entry.get("derivative", new_derivative), algo_info
     )
 
     if (new_criterion is not None or new_derivative is not None) and logging:
@@ -243,7 +243,7 @@ def internal_criterion_and_derivative_template(
         )
 
     res = _get_output_for_optimizer(
-        new_criterion, new_derivative, task, algorithm_info, direction
+        new_criterion, new_derivative, task, algo_info, direction
     )
     return res
 
@@ -291,12 +291,12 @@ def _determine_to_dos(task, cache_entry, derivative, criterion_and_derivative):
     return to_dos
 
 
-def _penalty_and_derivative(x, first_eval, error_penalty, algorithm_info):
+def _penalty_and_derivative(x, first_eval, error_penalty, algo_info):
     constant = error_penalty["constant"]
     slope = error_penalty["slope"]
     x0 = first_eval["internal_params"]
 
-    primary = algorithm_info["primary_criterion_entry"]
+    primary = algo_info.primary_criterion_entry
 
     if primary == "value":
         penalty = _penalty_value(x, constant, slope, x0)
@@ -360,10 +360,10 @@ def _cache_new_evaluations(new_criterion, new_derivative, x_hash, cache, cache_s
     cache[x_hash] = cache_entry
 
 
-def _check_and_harmonize_criterion_output(output, algorithm_info):
+def _check_and_harmonize_criterion_output(output, algo_info):
 
-    algo_name = algorithm_info.get("name", "your algorithm")
-    primary = algorithm_info["primary_criterion_entry"]
+    algo_name = getattr(algo_info, "name", "your algorithm")
+    primary = algo_info.primary_criterion_entry
 
     if output is not None:
         if np.isscalar(output):
@@ -385,8 +385,8 @@ def _check_and_harmonize_criterion_output(output, algorithm_info):
     return output
 
 
-def _check_and_harmonize_derivative(derivative, algorithm_info):
-    primary = algorithm_info["primary_criterion_entry"]
+def _check_and_harmonize_derivative(derivative, algo_info):
+    primary = algo_info.primary_criterion_entry
 
     if not isinstance(derivative, dict) and derivative is not None:
         derivative = {primary: derivative}
@@ -460,9 +460,9 @@ def _log_new_evaluations(
 
 
 def _get_output_for_optimizer(
-    new_criterion, new_derivative, task, algorithm_info, direction
+    new_criterion, new_derivative, task, algo_info, direction
 ):
-    primary = algorithm_info["primary_criterion_entry"]
+    primary = algo_info.primary_criterion_entry
 
     if "criterion" in task:
         if primary != "dict":

--- a/src/estimagic/optimization/nag_optimizers.py
+++ b/src/estimagic/optimization/nag_optimizers.py
@@ -15,6 +15,7 @@ import numpy as np
 from estimagic.config import IS_DFOLS_INSTALLED
 from estimagic.config import IS_PYBOBYQA_INSTALLED
 from estimagic.decorators import mark_minimizer
+from estimagic.exceptions import NotInstalledError
 from estimagic.optimization.algo_options import CLIP_CRITERION_IF_OVERFLOWING
 from estimagic.optimization.algo_options import (
     CONVERGENCE_MINIMAL_TRUSTREGION_RADIUS_TOLERANCE,
@@ -102,8 +103,8 @@ def nag_dfols(
 
     """
     if not IS_DFOLS_INSTALLED:
-        raise NotImplementedError(
-            "The dfols package is not installed and required for 'nag_dfols'. "
+        raise NotInstalledError(
+            "The 'nag_dfols' algorithm requires the DFO-LS package to be installed."
             "You can install it with 'pip install DFO-LS'. "
             "For additional installation instructions visit: ",
             r"https://numericalalgorithmsgroup.github.io/dfols/build/html/install.html",
@@ -294,9 +295,9 @@ def nag_pybobyqa(
 
     """
     if not IS_PYBOBYQA_INSTALLED:
-        raise NotImplementedError(
-            "The pybobyqa package is not installed and required for 'nag_pybobyqa'. "
-            "You can install it with 'pip install Py-BOBYQA'. "
+        raise NotInstalledError(
+            "The 'nag_pybobyqa' algorithm requires the Py-BOBYQA package to be "
+            "installed. You can install it with 'pip install Py-BOBYQA'. "
             "For additional installation instructions visit: ",
             r"https://numericalalgorithmsgroup.github.io/pybobyqa/build/html/"
             "install.html",

--- a/src/estimagic/optimization/nag_optimizers.py
+++ b/src/estimagic/optimization/nag_optimizers.py
@@ -10,11 +10,11 @@ The following arguments are not supported as ``algo_options``:
 
 """
 import warnings
-from functools import partial
 
 import numpy as np
 from estimagic.config import IS_DFOLS_INSTALLED
 from estimagic.config import IS_PYBOBYQA_INSTALLED
+from estimagic.decorators import mark_minimizer
 from estimagic.optimization.algo_options import CLIP_CRITERION_IF_OVERFLOWING
 from estimagic.optimization.algo_options import (
     CONVERGENCE_MINIMAL_TRUSTREGION_RADIUS_TOLERANCE,
@@ -55,8 +55,15 @@ if IS_DFOLS_INSTALLED:
     import dfols
 
 
+@mark_minimizer(
+    name="nag_dfols",
+    primary_criterion_entry="root_contributions",
+    disable_cache=True,
+    needs_scaling=True,
+    is_available=IS_DFOLS_INSTALLED,
+)
 def nag_dfols(
-    criterion_and_derivative,
+    criterion,
     x,
     lower_bounds,
     upper_bounds,
@@ -110,14 +117,6 @@ def nag_dfols(
             "trustregion_method_to_replace_extra_points must be "
             "'geometry_improving', 'momentum' or None."
         )
-
-    algo_info = {
-        "name": "nag_dfols",
-        "primary_criterion_entry": "root_contributions",
-        # does not really parallelize but we want to disable caching for noise averaging
-        "parallelizes": True,
-        "needs_scaling": False,
-    }
 
     advanced_options, trustregion_reset_options = _create_nag_advanced_options(
         x=x,
@@ -231,10 +230,6 @@ def nag_dfols(
 
     advanced_options.update(dfols_options)
 
-    criterion = partial(
-        criterion_and_derivative, task="criterion", algorithm_info=algo_info
-    )
-
     res = dfols.solve(
         criterion,
         x0=x,
@@ -254,8 +249,14 @@ def nag_dfols(
     return _process_nag_result(res, len(x))
 
 
+@mark_minimizer(
+    name="nag_dfols",
+    disable_cache=True,
+    needs_scaling=True,
+    is_available=IS_PYBOBYQA_INSTALLED,
+)
 def nag_pybobyqa(
-    criterion_and_derivative,
+    criterion,
     x,
     lower_bounds,
     upper_bounds,
@@ -304,16 +305,6 @@ def nag_pybobyqa(
     if convergence_criterion_value is None:
         convergence_criterion_value = -np.inf
 
-    algo_info = {
-        "name": "nag_pybobyqa",
-        "primary_criterion_entry": "value",
-        # does not really parallelize but we want to disable caching for noise averaging
-        "parallelizes": True,
-        "needs_scaling": False,
-    }
-    criterion = partial(
-        criterion_and_derivative, task="criterion", algorithm_info=algo_info
-    )
     advanced_options, trustregion_reset_options = _create_nag_advanced_options(
         x=x,
         noise_multiplicative_level=noise_multiplicative_level,

--- a/src/estimagic/optimization/neldermead.py
+++ b/src/estimagic/optimization/neldermead.py
@@ -1,10 +1,9 @@
 """
 Implementation of parallelosation of Nelder-Mead algorithm
 """
-from functools import partial
-
 import numpy as np
 from estimagic import batch_evaluators
+from estimagic.decorators import mark_minimizer
 from estimagic.optimization.algo_options import (
     CONVERGENCE_SECOND_BEST_ABSOLUTE_CRITERION_TOLERANCE,
 )
@@ -14,8 +13,16 @@ from estimagic.optimization.algo_options import (
 from estimagic.optimization.algo_options import STOPPING_MAX_ITERATIONS
 
 
+@mark_minimizer(
+    name="parallel_neldermead",
+    primary_criterion_entry="value",
+    disable_cache=True,
+    parallelizes=True,
+    needs_scaling=True,
+    is_available=True,
+)
 def neldermead_parallel(
-    criterion_and_derivative,
+    criterion,
     x,
     *,
     init_simplex_method="gao_han",
@@ -33,8 +40,8 @@ def neldermead_parallel(
 
     Parameters
     ----------
-    criterion_and_derivative (callable): A function that takes a Numpy array_like as
-        an argument and return scalar floating point or a :class:`numpy.ndarray`
+    criterion (callable): A function that takes a Numpy array_like as
+        an argument and return scalar floating point.
 
     x (array_like): 1-D array of initial value of parameters
 
@@ -68,18 +75,6 @@ def neldermead_parallel(
         DESCRIPTION.
 
     """
-    algo_info = {
-        "primary_criterion_entry": "value",
-        "parallelizes": True,
-        "needs_scaling": True,
-        "name": "parallel_neldermead",
-    }
-    criterion = partial(
-        criterion_and_derivative,
-        task="criterion",
-        algorithm_info=algo_info,
-    )
-
     if x.ndim >= 1:
         x = x.ravel()  # check if the vector of initial values is one-dimensional
 

--- a/src/estimagic/optimization/neldermead.py
+++ b/src/estimagic/optimization/neldermead.py
@@ -16,7 +16,7 @@ from estimagic.optimization.algo_options import STOPPING_MAX_ITERATIONS
 @mark_minimizer(
     name="parallel_neldermead",
     primary_criterion_entry="value",
-    disable_cache=True,
+    disable_cache=False,
     parallelizes=True,
     needs_scaling=True,
     is_available=True,

--- a/src/estimagic/optimization/nlopt_optimizers.py
+++ b/src/estimagic/optimization/nlopt_optimizers.py
@@ -544,11 +544,10 @@ def nlopt_slsqp(
 
 
 @mark_minimizer(
-    ### klingt gradienten frei
     name="nlopt_direct",
     primary_criterion_entry="value",
     parallelizes=False,
-    needs_scaling=True,  ### vielleicht auch nicht
+    needs_scaling=True,
     disable_cache=False,
     is_available=IS_NLOPT_INSTALLED,
 )
@@ -605,8 +604,8 @@ def nlopt_direct(
 @mark_minimizer(
     name="nlopt_esch",
     primary_criterion_entry="value",
-    parallelizes=True,  ### because genetic
-    needs_scaling=True,  ### unclear to me if needed
+    parallelizes=False,
+    needs_scaling=True,
     disable_cache=False,
     is_available=IS_NLOPT_INSTALLED,
 )
@@ -648,8 +647,8 @@ def nlopt_esch(
 @mark_minimizer(
     name="nlopt_isres",
     primary_criterion_entry="value",
-    parallelizes=True,  ### because this has a population
-    needs_scaling=True,  ### unclear to me if needed
+    parallelizes=False,
+    needs_scaling=True,
     disable_cache=False,
     is_available=IS_NLOPT_INSTALLED,
 )
@@ -691,8 +690,8 @@ def nlopt_isres(
 @mark_minimizer(
     name="nlopt_crs2_lm",
     primary_criterion_entry="value",
-    parallelizes=True,  ### because this has a population
-    needs_scaling=True,  ### unclear to me if needed
+    parallelizes=False,
+    needs_scaling=True,
     disable_cache=False,
     is_available=IS_NLOPT_INSTALLED,
 )

--- a/src/estimagic/optimization/nlopt_optimizers.py
+++ b/src/estimagic/optimization/nlopt_optimizers.py
@@ -5,6 +5,7 @@ The documentation is heavily based on (nlopt documentation)[nlopt.readthedocs.io
 """
 import numpy as np
 from estimagic.config import IS_NLOPT_INSTALLED
+from estimagic.decorators import mark_minimizer
 from estimagic.optimization.algo_options import CONVERGENCE_ABSOLUTE_CRITERION_TOLERANCE
 from estimagic.optimization.algo_options import CONVERGENCE_ABSOLUTE_PARAMS_TOLERANCE
 from estimagic.optimization.algo_options import CONVERGENCE_RELATIVE_CRITERION_TOLERANCE
@@ -14,20 +15,20 @@ from estimagic.optimization.algo_options import (
     STOPPING_MAX_CRITERION_EVALUATIONS_GLOBAL,
 )
 
-
 if IS_NLOPT_INSTALLED:
     import nlopt
 
 
-DEFAULT_ALGO_INFO = {
-    "primary_criterion_entry": "value",
-    "parallelizes": False,
-    "needs_scaling": False,
-}
-
-
+@mark_minimizer(
+    name="nlopt_bobyqa",
+    primary_criterion_entry="value",
+    parallelizes=False,
+    needs_scaling=False,
+    disable_cache=False,
+    is_available=IS_NLOPT_INSTALLED,
+)
 def nlopt_bobyqa(
-    criterion_and_derivative,
+    criterion,
     x,
     lower_bounds,
     upper_bounds,
@@ -45,12 +46,12 @@ def nlopt_bobyqa(
 
     """
     out = _minimize_nlopt(
-        criterion_and_derivative,
+        criterion,
         x,
         lower_bounds,
         upper_bounds,
+        derivative=None,
         algorithm=nlopt.LN_BOBYQA,
-        algorithm_name="nlopt_bobyqa",
         convergence_xtol_rel=convergence_relative_params_tolerance,
         convergence_xtol_abs=convergence_absolute_params_tolerance,
         convergence_ftol_rel=convergence_relative_criterion_tolerance,
@@ -61,8 +62,16 @@ def nlopt_bobyqa(
     return out
 
 
+@mark_minimizer(
+    name="nlopt_neldermead",
+    primary_criterion_entry="value",
+    parallelizes=False,
+    needs_scaling=True,
+    disable_cache=False,
+    is_available=IS_NLOPT_INSTALLED,
+)
 def nlopt_neldermead(
-    criterion_and_derivative,
+    criterion,
     x,
     lower_bounds,
     upper_bounds,
@@ -80,12 +89,12 @@ def nlopt_neldermead(
     """
 
     out = _minimize_nlopt(
-        criterion_and_derivative,
+        criterion,
         x,
         lower_bounds,
         upper_bounds,
         algorithm=nlopt.LN_NELDERMEAD,
-        algorithm_name="nlopt_neldermead",
+        derivative=None,
         convergence_xtol_rel=convergence_relative_params_tolerance,
         convergence_xtol_abs=convergence_absolute_params_tolerance,
         convergence_ftol_rel=convergence_relative_criterion_tolerance,
@@ -96,8 +105,16 @@ def nlopt_neldermead(
     return out
 
 
+@mark_minimizer(
+    name="nlopt_praxis",
+    primary_criterion_entry="value",
+    parallelizes=False,
+    needs_scaling=True,
+    disable_cache=False,
+    is_available=IS_NLOPT_INSTALLED,
+)
 def nlopt_praxis(
-    criterion_and_derivative,
+    criterion,
     x,
     *,
     convergence_relative_params_tolerance=CONVERGENCE_RELATIVE_PARAMS_TOLERANCE,
@@ -111,28 +128,33 @@ def nlopt_praxis(
     For details see :ref:`list_of_nlopt_algorithms`.
 
     """
-    algo_info = DEFAULT_ALGO_INFO.copy()
-    algo_info.update({"needs_scaling": True})
     out = _minimize_nlopt(
-        criterion_and_derivative,
+        criterion,
         x,
         lower_bounds=None,
         upper_bounds=None,
         algorithm=nlopt.LN_PRAXIS,
-        algorithm_name="nlopt_praxis",
+        derivative=None,
         convergence_xtol_rel=convergence_relative_params_tolerance,
         convergence_xtol_abs=convergence_absolute_params_tolerance,
         convergence_ftol_rel=convergence_relative_criterion_tolerance,
         convergence_ftol_abs=convergence_absolute_criterion_tolerance,
         stopping_max_eval=stopping_max_criterion_evaluations,
-        algo_info=algo_info,
     )
 
     return out
 
 
+@mark_minimizer(
+    name="nlopt_cobyla",
+    primary_criterion_entry="value",
+    parallelizes=False,
+    needs_scaling=True,
+    disable_cache=False,
+    is_available=IS_NLOPT_INSTALLED,
+)
 def nlopt_cobyla(
-    criterion_and_derivative,
+    criterion,
     x,
     lower_bounds,
     upper_bounds,
@@ -150,12 +172,12 @@ def nlopt_cobyla(
     """
 
     out = _minimize_nlopt(
-        criterion_and_derivative,
+        criterion,
         x,
         lower_bounds,
         upper_bounds,
         algorithm=nlopt.LN_COBYLA,
-        algorithm_name="nlopt_cobyla",
+        derivative=None,
         convergence_xtol_rel=convergence_relative_params_tolerance,
         convergence_xtol_abs=convergence_absolute_params_tolerance,
         convergence_ftol_rel=convergence_relative_criterion_tolerance,
@@ -166,8 +188,16 @@ def nlopt_cobyla(
     return out
 
 
+@mark_minimizer(
+    name="nlopt_sbplx",
+    primary_criterion_entry="value",
+    parallelizes=False,
+    needs_scaling=True,
+    disable_cache=False,
+    is_available=IS_NLOPT_INSTALLED,
+)
 def nlopt_sbplx(
-    criterion_and_derivative,
+    criterion,
     x,
     lower_bounds,
     upper_bounds,
@@ -185,12 +215,11 @@ def nlopt_sbplx(
     """
 
     out = _minimize_nlopt(
-        criterion_and_derivative,
+        criterion,
         x,
         lower_bounds,
         upper_bounds,
         algorithm=nlopt.LN_SBPLX,
-        algorithm_name="nlopt_sbplx",
         convergence_xtol_rel=convergence_relative_params_tolerance,
         convergence_xtol_abs=convergence_absolute_params_tolerance,
         convergence_ftol_rel=convergence_relative_criterion_tolerance,
@@ -201,8 +230,16 @@ def nlopt_sbplx(
     return out
 
 
+@mark_minimizer(
+    name="nlopt_newuoa",
+    primary_criterion_entry="value",
+    parallelizes=False,
+    needs_scaling=True,
+    disable_cache=False,
+    is_available=IS_NLOPT_INSTALLED,
+)
 def nlopt_newuoa(
-    criterion_and_derivative,
+    criterion,
     x,
     lower_bounds,
     upper_bounds,
@@ -224,12 +261,11 @@ def nlopt_newuoa(
         algo = nlopt.LN_NEWUOA
 
     out = _minimize_nlopt(
-        criterion_and_derivative,
+        criterion,
         x,
         lower_bounds,
         upper_bounds,
         algorithm=algo,
-        algorithm_name="nlopt_newuoa",
         convergence_xtol_rel=convergence_relative_params_tolerance,
         convergence_xtol_abs=convergence_absolute_params_tolerance,
         convergence_ftol_rel=convergence_relative_criterion_tolerance,
@@ -240,8 +276,17 @@ def nlopt_newuoa(
     return out
 
 
+@mark_minimizer(
+    name="nlopt_tnewton",
+    primary_criterion_entry="value",
+    parallelizes=False,
+    needs_scaling=False,
+    disable_cache=False,
+    is_available=IS_NLOPT_INSTALLED,
+)
 def nlopt_tnewton(
-    criterion_and_derivative,
+    criterion,
+    derivative,
     x,
     lower_bounds,
     upper_bounds,
@@ -259,12 +304,12 @@ def nlopt_tnewton(
     """
 
     out = _minimize_nlopt(
-        criterion_and_derivative,
+        criterion,
         x,
         lower_bounds,
         upper_bounds,
         algorithm=nlopt.LD_TNEWTON,
-        algorithm_name="nlopt_tnewton",
+        derivative=derivative,
         convergence_xtol_rel=convergence_relative_params_tolerance,
         convergence_xtol_abs=convergence_absolute_params_tolerance,
         convergence_ftol_rel=convergence_relative_criterion_tolerance,
@@ -275,8 +320,17 @@ def nlopt_tnewton(
     return out
 
 
+@mark_minimizer(
+    name="nlopt_lbfgsb",
+    primary_criterion_entry="value",
+    parallelizes=False,
+    needs_scaling=False,
+    disable_cache=False,
+    is_available=IS_NLOPT_INSTALLED,
+)
 def nlopt_lbfgs(
-    criterion_and_derivative,
+    criterion,
+    derivative,
     x,
     lower_bounds,
     upper_bounds,
@@ -294,12 +348,12 @@ def nlopt_lbfgs(
     """
 
     out = _minimize_nlopt(
-        criterion_and_derivative,
+        criterion,
         x,
         lower_bounds,
         upper_bounds,
         algorithm=nlopt.LD_TNEWTON,
-        algorithm_name="nlopt_tnewton",
+        derivative=derivative,
         convergence_xtol_rel=convergence_relative_params_tolerance,
         convergence_xtol_abs=convergence_absolute_params_tolerance,
         convergence_ftol_rel=convergence_relative_criterion_tolerance,
@@ -310,8 +364,17 @@ def nlopt_lbfgs(
     return out
 
 
+@mark_minimizer(
+    name="nlopt_ccsaq",
+    primary_criterion_entry="value",
+    parallelizes=False,
+    needs_scaling=False,
+    disable_cache=False,
+    is_available=IS_NLOPT_INSTALLED,
+)
 def nlopt_ccsaq(
-    criterion_and_derivative,
+    criterion,
+    derivative,
     x,
     lower_bounds,
     upper_bounds,
@@ -329,12 +392,12 @@ def nlopt_ccsaq(
 
     """
     out = _minimize_nlopt(
-        criterion_and_derivative,
+        criterion,
         x,
         lower_bounds,
         upper_bounds,
         algorithm=nlopt.LD_CCSAQ,
-        algorithm_name="nlopt_ccsaq",
+        derivative=derivative,
         convergence_xtol_rel=convergence_relative_params_tolerance,
         convergence_xtol_abs=convergence_absolute_params_tolerance,
         convergence_ftol_rel=convergence_relative_criterion_tolerance,
@@ -345,8 +408,17 @@ def nlopt_ccsaq(
     return out
 
 
+@mark_minimizer(
+    name="nlopt_mma",
+    primary_criterion_entry="value",
+    parallelizes=False,
+    needs_scaling=False,
+    disable_cache=False,
+    is_available=IS_NLOPT_INSTALLED,
+)
 def nlopt_mma(
-    criterion_and_derivative,
+    criterion,
+    derivative,
     x,
     lower_bounds,
     upper_bounds,
@@ -364,12 +436,12 @@ def nlopt_mma(
 
     """
     out = _minimize_nlopt(
-        criterion_and_derivative,
+        criterion,
         x,
         lower_bounds,
         upper_bounds,
         algorithm=nlopt.LD_MMA,
-        algorithm_name="nlopt_mma",
+        derivative=derivative,
         convergence_xtol_rel=convergence_relative_params_tolerance,
         convergence_xtol_abs=convergence_absolute_params_tolerance,
         convergence_ftol_rel=convergence_relative_criterion_tolerance,
@@ -380,8 +452,17 @@ def nlopt_mma(
     return out
 
 
+@mark_minimizer(
+    name="nlopt_var",
+    primary_criterion_entry="value",
+    parallelizes=False,
+    needs_scaling=False,
+    disable_cache=False,
+    is_available=IS_NLOPT_INSTALLED,
+)
 def nlopt_var(
-    criterion_and_derivative,
+    criterion,
+    derivative,
     x,
     lower_bounds,
     upper_bounds,
@@ -404,12 +485,12 @@ def nlopt_var(
     else:
         algo = nlopt.LD_VAR2
     out = _minimize_nlopt(
-        criterion_and_derivative,
+        criterion,
         x,
         lower_bounds,
         upper_bounds,
         algorithm=algo,
-        algorithm_name="nlopt_var",
+        derivative=derivative,
         convergence_xtol_rel=convergence_relative_params_tolerance,
         convergence_xtol_abs=convergence_absolute_params_tolerance,
         convergence_ftol_rel=convergence_relative_criterion_tolerance,
@@ -420,8 +501,17 @@ def nlopt_var(
     return out
 
 
+@mark_minimizer(
+    name="nlopt_slsqp",
+    primary_criterion_entry="value",
+    parallelizes=False,
+    needs_scaling=False,
+    disable_cache=False,
+    is_available=IS_NLOPT_INSTALLED,
+)
 def nlopt_slsqp(
-    criterion_and_derivative,
+    criterion,
+    derivative,
     x,
     lower_bounds,
     upper_bounds,
@@ -438,12 +528,12 @@ def nlopt_slsqp(
 
     """
     out = _minimize_nlopt(
-        criterion_and_derivative,
+        criterion,
         x,
         lower_bounds,
         upper_bounds,
         algorithm=nlopt.LD_SLSQP,
-        algorithm_name="nlopt_slsqp",
+        derivative=derivative,
         convergence_xtol_rel=convergence_relative_params_tolerance,
         convergence_xtol_abs=convergence_absolute_params_tolerance,
         convergence_ftol_rel=convergence_relative_criterion_tolerance,
@@ -453,8 +543,17 @@ def nlopt_slsqp(
     return out
 
 
+@mark_minimizer(
+    ### klingt gradienten frei
+    name="nlopt_direct",
+    primary_criterion_entry="value",
+    parallelizes=False,
+    needs_scaling=True,  ### vielleicht auch nicht
+    disable_cache=False,
+    is_available=IS_NLOPT_INSTALLED,
+)
 def nlopt_direct(
-    criterion_and_derivative,
+    criterion,
     x,
     lower_bounds,
     upper_bounds,
@@ -486,12 +585,11 @@ def nlopt_direct(
     elif not locally_biased and not random_search and unscaled_bounds:
         algo = nlopt.GN_DIRECT_NOSCAL
     out = _minimize_nlopt(
-        criterion_and_derivative,
+        criterion,
         x,
         lower_bounds,
         upper_bounds,
         algorithm=algo,
-        algorithm_name="nlopt_direct",
         convergence_xtol_rel=convergence_relative_params_tolerance,
         convergence_xtol_abs=convergence_absolute_params_tolerance,
         convergence_ftol_rel=convergence_relative_criterion_tolerance,
@@ -504,8 +602,16 @@ def nlopt_direct(
     return out
 
 
+@mark_minimizer(
+    name="nlopt_esch",
+    primary_criterion_entry="value",
+    parallelizes=True,  ### because genetic
+    needs_scaling=True,  ### unclear to me if needed
+    disable_cache=False,
+    is_available=IS_NLOPT_INSTALLED,
+)
 def nlopt_esch(
-    criterion_and_derivative,
+    criterion,
     x,
     lower_bounds,
     upper_bounds,
@@ -522,12 +628,11 @@ def nlopt_esch(
 
     """
     out = _minimize_nlopt(
-        criterion_and_derivative,
+        criterion,
         x,
         lower_bounds,
         upper_bounds,
         algorithm=nlopt.GN_ESCH,
-        algorithm_name="nlopt_esch",
         convergence_xtol_rel=convergence_relative_params_tolerance,
         convergence_xtol_abs=convergence_absolute_params_tolerance,
         convergence_ftol_rel=convergence_relative_criterion_tolerance,
@@ -540,8 +645,16 @@ def nlopt_esch(
     return out
 
 
+@mark_minimizer(
+    name="nlopt_isres",
+    primary_criterion_entry="value",
+    parallelizes=True,  ### because this has a population
+    needs_scaling=True,  ### unclear to me if needed
+    disable_cache=False,
+    is_available=IS_NLOPT_INSTALLED,
+)
 def nlopt_isres(
-    criterion_and_derivative,
+    criterion,
     x,
     lower_bounds,
     upper_bounds,
@@ -558,12 +671,11 @@ def nlopt_isres(
 
     """
     out = _minimize_nlopt(
-        criterion_and_derivative,
+        criterion,
         x,
         lower_bounds,
         upper_bounds,
         algorithm=nlopt.GN_ISRES,
-        algorithm_name="nlopt_isres",
         convergence_xtol_rel=convergence_relative_params_tolerance,
         convergence_xtol_abs=convergence_absolute_params_tolerance,
         convergence_ftol_rel=convergence_relative_criterion_tolerance,
@@ -576,8 +688,16 @@ def nlopt_isres(
     return out
 
 
+@mark_minimizer(
+    name="nlopt_crs2_lm",
+    primary_criterion_entry="value",
+    parallelizes=True,  ### because this has a population
+    needs_scaling=True,  ### unclear to me if needed
+    disable_cache=False,
+    is_available=IS_NLOPT_INSTALLED,
+)
 def nlopt_crs2_lm(
-    criterion_and_derivative,
+    criterion,
     x,
     lower_bounds,
     upper_bounds,
@@ -597,12 +717,11 @@ def nlopt_crs2_lm(
     if population_size is None:
         population_size = 10 * (len(x) + 1)
     out = _minimize_nlopt(
-        criterion_and_derivative,
+        criterion,
         x,
         lower_bounds,
         upper_bounds,
         algorithm=nlopt.GN_CRS2_LM,
-        algorithm_name="nlopt_crs2_lm",
         convergence_xtol_rel=convergence_relative_params_tolerance,
         convergence_xtol_abs=convergence_absolute_params_tolerance,
         convergence_ftol_rel=convergence_relative_criterion_tolerance,
@@ -617,43 +736,29 @@ def nlopt_crs2_lm(
 
 
 def _minimize_nlopt(
-    criterion_and_derivative,
+    criterion,
     x,
     lower_bounds,
     upper_bounds,
     algorithm,
-    algorithm_name,
     *,
+    derivative=None,
     convergence_xtol_rel=None,
     convergence_xtol_abs=None,
     convergence_ftol_rel=None,
     convergence_ftol_abs=None,
     stopping_max_eval=None,
     population_size=None,
-    algo_info=None,
 ):
     """Run actual nlopt optimization argument, set relevant attributes."""
-    if algo_info is None:
-        algo_info = DEFAULT_ALGO_INFO.copy()
-    else:
-        algo_info = algo_info.copy()
-    algo_info["name"] = algorithm_name
 
     def func(x, grad):
         if grad.size > 0:
-            criterion, derivative = criterion_and_derivative(
-                x,
-                task="criterion_and_derivative",
-                algorithm_info=algo_info,
-            )
-            grad[:] = derivative
+            criterion_value = criterion(x)
+            grad[:] = derivative(x)
         else:
-            criterion = criterion_and_derivative(
-                x,
-                task="criterion",
-                algorithm_info=algo_info,
-            )
-        return criterion
+            criterion_value = criterion(x)
+        return criterion_value
 
     opt = nlopt.opt(algorithm, x.shape[0])
     if convergence_ftol_rel is not None:

--- a/src/estimagic/optimization/pounders.py
+++ b/src/estimagic/optimization/pounders.py
@@ -1,11 +1,11 @@
 """Implement the POUNDERS algorithm"""
 import warnings
 from copy import copy
-from functools import partial
 
 import estimagic.batch_evaluators as be
 import numpy as np
 from estimagic.config import DEFAULT_N_CORES
+from estimagic.decorators import mark_minimizer
 from estimagic.optimization.history import LeastSquaresHistory
 from estimagic.optimization.pounders_auxiliary import (
     add_geomtery_points_to_make_main_model_fully_linear,
@@ -32,8 +32,16 @@ from estimagic.optimization.pounders_auxiliary import (
 from estimagic.optimization.pounders_auxiliary import update_trustregion_radius
 
 
+@mark_minimizer(
+    name="pounders",
+    primary_criterion_entry="root_contributions",
+    needs_scaling=True,
+    parallelizes=True,
+    disable_cache=False,
+    is_available=True,
+)
 def pounders(
-    criterion_and_derivative,
+    criterion,
     x,
     lower_bounds,
     upper_bounds,
@@ -60,19 +68,10 @@ def pounders(
 ):
     """Find the local minimum to a non-linear least-squares problem using POUNDERS.
     For details, see :ref:`_own_algorithms`.
+
     """
     if isinstance(batch_evaluator, str):
         batch_evaluator = getattr(be, f"{batch_evaluator}_batch_evaluator")
-
-    algorithm_info = {
-        "primary_criterion_entry": "root_contributions",
-        "parallelizes": False,
-        "needs_scaling": True,
-        "name": "pounders",
-    }
-    criterion = partial(
-        criterion_and_derivative, algorithm_info=algorithm_info, task="criterion"
-    )
 
     if max_interpolation_points is None:
         max_interpolation_points = 2 * x.shape[0] + 1

--- a/src/estimagic/optimization/pygmo_optimizers.py
+++ b/src/estimagic/optimization/pygmo_optimizers.py
@@ -1297,7 +1297,6 @@ def _minimize_pygmo(
     prob = _create_problem(
         func=criterion,
         bounds=bounds,
-        gradient_=derivative,
         dim=len(x),
         batch_evaluator=batch_evaluator,
         n_cores=n_cores,
@@ -1312,7 +1311,7 @@ def _minimize_pygmo(
     return result
 
 
-def _create_problem(func, bounds, gradient_, dim, batch_evaluator, n_cores):
+def _create_problem(func, bounds, dim, batch_evaluator, n_cores):
     class Problem:
         def fitness(self, x):
             return [func(x)]
@@ -1321,10 +1320,7 @@ def _create_problem(func, bounds, gradient_, dim, batch_evaluator, n_cores):
             return bounds
 
         def gradient(self, dv):
-            if gradient_ is not None:
-                return gradient_(dv)
-            else:
-                return None
+            raise ValueError("No pygmo optimizer should use a gradient.")
 
         def batch_fitness(self, dvs):
             dv_list = dvs.reshape(-1, dim)

--- a/src/estimagic/optimization/pygmo_optimizers.py
+++ b/src/estimagic/optimization/pygmo_optimizers.py
@@ -1,10 +1,10 @@
 """Implement pygmo optimizers."""
-import functools
 import warnings
 
 import numpy as np
 from estimagic import batch_evaluators
 from estimagic.config import IS_PYGMO_INSTALLED
+from estimagic.decorators import mark_minimizer
 from estimagic.exceptions import NotInstalledError
 from estimagic.optimization.algo_options import CONVERGENCE_RELATIVE_PARAMS_TOLERANCE
 from estimagic.optimization.algo_options import (
@@ -19,8 +19,16 @@ except ImportError:
     pass
 
 
+@mark_minimizer(
+    name="pygmo_gaco",
+    primary_criterion_entry="value",
+    parallelizes=True,
+    needs_scaling=True,
+    disable_cache=False,
+    is_available=IS_PYGMO_INSTALLED,
+)
 def pygmo_gaco(
-    criterion_and_derivative,
+    criterion,
     x,
     lower_bounds,
     upper_bounds,
@@ -84,7 +92,7 @@ def pygmo_gaco(
     )
 
     res = _minimize_pygmo(
-        criterion_and_derivative=criterion_and_derivative,
+        criterion=criterion,
         x=x,
         lower_bounds=lower_bounds,
         upper_bounds=upper_bounds,
@@ -94,8 +102,16 @@ def pygmo_gaco(
     return res
 
 
+@mark_minimizer(
+    name="pygmo_bee_colony",
+    primary_criterion_entry="value",
+    parallelizes=True,
+    needs_scaling=True,
+    disable_cache=False,
+    is_available=IS_PYGMO_INSTALLED,
+)
 def pygmo_bee_colony(
-    criterion_and_derivative,
+    criterion,
     x,
     lower_bounds,
     upper_bounds,
@@ -129,7 +145,7 @@ def pygmo_bee_colony(
     )
 
     res = _minimize_pygmo(
-        criterion_and_derivative=criterion_and_derivative,
+        criterion=criterion,
         x=x,
         lower_bounds=lower_bounds,
         upper_bounds=upper_bounds,
@@ -139,8 +155,16 @@ def pygmo_bee_colony(
     return res
 
 
+@mark_minimizer(
+    name="pygmo_de",
+    primary_criterion_entry="value",
+    parallelizes=True,
+    needs_scaling=True,
+    disable_cache=False,
+    is_available=IS_PYGMO_INSTALLED,
+)
 def pygmo_de(
-    criterion_and_derivative,
+    criterion,
     x,
     lower_bounds,
     upper_bounds,
@@ -201,7 +225,7 @@ def pygmo_de(
     )
 
     res = _minimize_pygmo(
-        criterion_and_derivative=criterion_and_derivative,
+        criterion=criterion,
         x=x,
         lower_bounds=lower_bounds,
         upper_bounds=upper_bounds,
@@ -211,8 +235,16 @@ def pygmo_de(
     return res
 
 
+@mark_minimizer(
+    name="pygmo_sea",
+    primary_criterion_entry="value",
+    parallelizes=True,
+    needs_scaling=True,
+    disable_cache=False,
+    is_available=IS_PYGMO_INSTALLED,
+)
 def pygmo_sea(
-    criterion_and_derivative,
+    criterion,
     x,
     lower_bounds,
     upper_bounds,
@@ -244,7 +276,7 @@ def pygmo_sea(
     )
 
     res = _minimize_pygmo(
-        criterion_and_derivative=criterion_and_derivative,
+        criterion=criterion,
         x=x,
         lower_bounds=lower_bounds,
         upper_bounds=upper_bounds,
@@ -254,8 +286,16 @@ def pygmo_sea(
     return res
 
 
+@mark_minimizer(
+    name="pygmo_sga",
+    primary_criterion_entry="value",
+    parallelizes=True,
+    needs_scaling=True,
+    disable_cache=False,
+    is_available=IS_PYGMO_INSTALLED,
+)
 def pygmo_sga(
-    criterion_and_derivative,
+    criterion,
     x,
     lower_bounds,
     upper_bounds,
@@ -357,7 +397,7 @@ def pygmo_sga(
     )
 
     res = _minimize_pygmo(
-        criterion_and_derivative=criterion_and_derivative,
+        criterion=criterion,
         x=x,
         lower_bounds=lower_bounds,
         upper_bounds=upper_bounds,
@@ -367,8 +407,16 @@ def pygmo_sga(
     return res
 
 
+@mark_minimizer(
+    name="pygmo_sade",
+    primary_criterion_entry="value",
+    parallelizes=True,
+    needs_scaling=True,
+    disable_cache=False,
+    is_available=IS_PYGMO_INSTALLED,
+)
 def pygmo_sade(
-    criterion_and_derivative,
+    criterion,
     x,
     lower_bounds,
     upper_bounds,
@@ -437,7 +485,7 @@ def pygmo_sade(
     )
 
     res = _minimize_pygmo(
-        criterion_and_derivative=criterion_and_derivative,
+        criterion=criterion,
         x=x,
         lower_bounds=lower_bounds,
         upper_bounds=upper_bounds,
@@ -447,8 +495,16 @@ def pygmo_sade(
     return res
 
 
+@mark_minimizer(
+    name="pygmo_cmaes",
+    primary_criterion_entry="value",
+    parallelizes=True,
+    needs_scaling=True,
+    disable_cache=False,
+    is_available=IS_PYGMO_INSTALLED,
+)
 def pygmo_cmaes(
-    criterion_and_derivative,
+    criterion,
     x,
     lower_bounds,
     upper_bounds,
@@ -502,7 +558,7 @@ def pygmo_cmaes(
     )
 
     res = _minimize_pygmo(
-        criterion_and_derivative=criterion_and_derivative,
+        criterion=criterion,
         x=x,
         lower_bounds=lower_bounds,
         upper_bounds=upper_bounds,
@@ -512,8 +568,16 @@ def pygmo_cmaes(
     return res
 
 
+@mark_minimizer(
+    name="pygmo_simulated_annealing",
+    primary_criterion_entry="value",
+    parallelizes=True,
+    needs_scaling=True,
+    disable_cache=False,
+    is_available=IS_PYGMO_INSTALLED,
+)
 def pygmo_simulated_annealing(
-    criterion_and_derivative,
+    criterion,
     x,
     lower_bounds,
     upper_bounds,
@@ -560,7 +624,7 @@ def pygmo_simulated_annealing(
     )
 
     res = _minimize_pygmo(
-        criterion_and_derivative=criterion_and_derivative,
+        criterion=criterion,
         x=x,
         lower_bounds=lower_bounds,
         upper_bounds=upper_bounds,
@@ -570,8 +634,16 @@ def pygmo_simulated_annealing(
     return res
 
 
+@mark_minimizer(
+    name="pygmo_pso",
+    primary_criterion_entry="value",
+    parallelizes=True,
+    needs_scaling=True,
+    disable_cache=False,
+    is_available=IS_PYGMO_INSTALLED,
+)
 def pygmo_pso(
-    criterion_and_derivative,
+    criterion,
     x,
     lower_bounds,
     upper_bounds,
@@ -648,7 +720,7 @@ def pygmo_pso(
     )
 
     res = _minimize_pygmo(
-        criterion_and_derivative=criterion_and_derivative,
+        criterion=criterion,
         x=x,
         lower_bounds=lower_bounds,
         upper_bounds=upper_bounds,
@@ -658,8 +730,16 @@ def pygmo_pso(
     return res
 
 
+@mark_minimizer(
+    name="pygmo_pso_gen",
+    primary_criterion_entry="value",
+    parallelizes=True,
+    needs_scaling=True,
+    disable_cache=False,
+    is_available=IS_PYGMO_INSTALLED,
+)
 def pygmo_pso_gen(
-    criterion_and_derivative,
+    criterion,
     x,
     lower_bounds,
     upper_bounds,
@@ -735,7 +815,7 @@ def pygmo_pso_gen(
     )
 
     res = _minimize_pygmo(
-        criterion_and_derivative=criterion_and_derivative,
+        criterion=criterion,
         x=x,
         lower_bounds=lower_bounds,
         upper_bounds=upper_bounds,
@@ -745,8 +825,16 @@ def pygmo_pso_gen(
     return res
 
 
+@mark_minimizer(
+    name="pygmo_mbh",
+    primary_criterion_entry="value",
+    parallelizes=True,
+    needs_scaling=True,
+    disable_cache=False,
+    is_available=IS_PYGMO_INSTALLED,
+)
 def pygmo_mbh(
-    criterion_and_derivative,
+    criterion,
     x,
     lower_bounds,
     upper_bounds,
@@ -788,7 +876,7 @@ def pygmo_mbh(
     )
 
     res = _minimize_pygmo(
-        criterion_and_derivative=criterion_and_derivative,
+        criterion=criterion,
         x=x,
         lower_bounds=lower_bounds,
         upper_bounds=upper_bounds,
@@ -798,8 +886,16 @@ def pygmo_mbh(
     return res
 
 
+@mark_minimizer(
+    name="pygmo_xnes",
+    primary_criterion_entry="value",
+    parallelizes=True,
+    needs_scaling=True,
+    disable_cache=False,
+    is_available=IS_PYGMO_INSTALLED,
+)
 def pygmo_xnes(
-    criterion_and_derivative,
+    criterion,
     x,
     lower_bounds,
     upper_bounds,
@@ -851,7 +947,7 @@ def pygmo_xnes(
     )
 
     res = _minimize_pygmo(
-        criterion_and_derivative=criterion_and_derivative,
+        criterion=criterion,
         x=x,
         lower_bounds=lower_bounds,
         upper_bounds=upper_bounds,
@@ -861,8 +957,16 @@ def pygmo_xnes(
     return res
 
 
+@mark_minimizer(
+    name="pygmo_gwo",
+    primary_criterion_entry="value",
+    parallelizes=True,
+    needs_scaling=True,
+    disable_cache=False,
+    is_available=IS_PYGMO_INSTALLED,
+)
 def pygmo_gwo(
-    criterion_and_derivative,
+    criterion,
     x,
     lower_bounds,
     upper_bounds,
@@ -874,7 +978,7 @@ def pygmo_gwo(
     discard_start_params=False,
     stopping_max_iterations=STOPPING_MAX_ITERATIONS_GENETIC,
 ):
-    """Minimize a scalar function usinng the Grey Wolf Optimizer.
+    """Minimize a scalar function using the Grey Wolf Optimizer.
 
     For details see :ref:`list_of_pygmo_algorithms`.
 
@@ -894,7 +998,7 @@ def pygmo_gwo(
     )
 
     res = _minimize_pygmo(
-        criterion_and_derivative=criterion_and_derivative,
+        criterion=criterion,
         x=x,
         lower_bounds=lower_bounds,
         upper_bounds=upper_bounds,
@@ -904,8 +1008,16 @@ def pygmo_gwo(
     return res
 
 
+@mark_minimizer(
+    name="pygmo_compass_search",
+    primary_criterion_entry="value",
+    parallelizes=True,
+    needs_scaling=True,
+    disable_cache=False,
+    is_available=IS_PYGMO_INSTALLED,
+)
 def pygmo_compass_search(
-    criterion_and_derivative,
+    criterion,
     x,
     lower_bounds,
     upper_bounds,
@@ -952,7 +1064,7 @@ def pygmo_compass_search(
     )
 
     res = _minimize_pygmo(
-        criterion_and_derivative=criterion_and_derivative,
+        criterion=criterion,
         x=x,
         lower_bounds=lower_bounds,
         upper_bounds=upper_bounds,
@@ -962,8 +1074,16 @@ def pygmo_compass_search(
     return res
 
 
+@mark_minimizer(
+    name="pygmo_ihs",
+    primary_criterion_entry="value",
+    parallelizes=True,
+    needs_scaling=True,
+    disable_cache=False,
+    is_available=IS_PYGMO_INSTALLED,
+)
 def pygmo_ihs(
-    criterion_and_derivative,
+    criterion,
     x,
     lower_bounds,
     upper_bounds,
@@ -1013,7 +1133,7 @@ def pygmo_ihs(
     )
 
     res = _minimize_pygmo(
-        criterion_and_derivative=criterion_and_derivative,
+        criterion=criterion,
         x=x,
         lower_bounds=lower_bounds,
         upper_bounds=upper_bounds,
@@ -1023,8 +1143,16 @@ def pygmo_ihs(
     return res
 
 
+@mark_minimizer(
+    name="pygmo_de1220",
+    primary_criterion_entry="value",
+    parallelizes=True,
+    needs_scaling=True,
+    disable_cache=False,
+    is_available=IS_PYGMO_INSTALLED,
+)
 def pygmo_de1220(
-    criterion_and_derivative,
+    criterion,
     x,
     lower_bounds,
     upper_bounds,
@@ -1100,7 +1228,7 @@ def pygmo_de1220(
     )
 
     res = _minimize_pygmo(
-        criterion_and_derivative=criterion_and_derivative,
+        criterion=criterion,
         x=x,
         lower_bounds=lower_bounds,
         upper_bounds=upper_bounds,
@@ -1114,12 +1242,18 @@ def pygmo_de1220(
 
 
 def _minimize_pygmo(
-    criterion_and_derivative, x, lower_bounds, upper_bounds, method, algo_options=None
+    criterion,
+    x,
+    lower_bounds,
+    upper_bounds,
+    method,
+    algo_options,
+    derivative=None,
 ):
     """Minimize a function with pygmo.
 
     Args:
-        criterion_and_derivative (callable):
+        criterion (callable):
         x (np.ndarray): Starting values of the parameters.
         lower_bounds (np.ndarray):
         upper_bounds (np.ndarray):
@@ -1151,9 +1285,7 @@ def _minimize_pygmo(
             "instructions."
         )
 
-    algo_options = {} if algo_options is None else algo_options.copy()
     population_size = algo_options.pop("population_size", 1)
-
     batch_evaluator = algo_options.pop("batch_evaluator", "joblib_batch_evaluator")
     if isinstance(batch_evaluator, str):
         batch_evaluator = getattr(batch_evaluators, batch_evaluator)
@@ -1161,24 +1293,11 @@ def _minimize_pygmo(
     seed = algo_options.pop("seed", None)
     discard_start_params = algo_options.pop("discard_start_params", False)
 
-    algo_info = {
-        "parallelizes": n_cores != 1,
-        "name": f"pygmo_{method}",
-        "needs_scaling": True,
-        "primary_criterion_entry": "value",
-    }
-    func = functools.partial(
-        criterion_and_derivative, task="criterion", algorithm_info=algo_info
-    )
-    gradient = functools.partial(
-        criterion_and_derivative, task="derivative", algorithm_info=algo_info
-    )
-
     bounds = (lower_bounds, upper_bounds)
     prob = _create_problem(
-        func=func,
+        func=criterion,
         bounds=bounds,
-        gradient_=gradient,
+        gradient_=derivative,
         dim=len(x),
         batch_evaluator=batch_evaluator,
         n_cores=n_cores,
@@ -1202,7 +1321,10 @@ def _create_problem(func, bounds, gradient_, dim, batch_evaluator, n_cores):
             return bounds
 
         def gradient(self, dv):
-            return gradient_(dv)
+            if gradient_ is not None:
+                return gradient_(dv)
+            else:
+                return None
 
         def batch_fitness(self, dvs):
             dv_list = dvs.reshape(-1, dim)

--- a/src/estimagic/optimization/pygmo_optimizers.py
+++ b/src/estimagic/optimization/pygmo_optimizers.py
@@ -5,6 +5,7 @@ import warnings
 import numpy as np
 from estimagic import batch_evaluators
 from estimagic.config import IS_PYGMO_INSTALLED
+from estimagic.exceptions import NotInstalledError
 from estimagic.optimization.algo_options import CONVERGENCE_RELATIVE_PARAMS_TOLERANCE
 from estimagic.optimization.algo_options import (
     STOPPING_MAX_CRITERION_EVALUATIONS_GLOBAL,
@@ -1143,8 +1144,11 @@ def _minimize_pygmo(
 
     """
     if not IS_PYGMO_INSTALLED:
-        raise NotImplementedError(
-            f"The pygmo package is not installed and required for '{method}'."
+        raise NotInstalledError(
+            f"The {method} algorithm requires the pygmo package to be installed. "
+            "You can install it with 'conda install -c conda-forge pygmo'. Visit "
+            "https://esa.github.io/pygmo2/install.html for more detailed installation "
+            "instructions."
         )
 
     algo_options = {} if algo_options is None else algo_options.copy()

--- a/src/estimagic/optimization/scipy_optimizers.py
+++ b/src/estimagic/optimization/scipy_optimizers.py
@@ -61,12 +61,6 @@ from estimagic.optimization.algo_options import STOPPING_MAX_CRITERION_EVALUATIO
 from estimagic.optimization.algo_options import STOPPING_MAX_ITERATIONS
 from estimagic.utilities import calculate_trustregion_initial_radius
 
-DEFAULT_ALGO_INFO = {
-    "primary_criterion_entry": "value",
-    "parallelizes": False,
-    "needs_scaling": False,
-}
-
 
 @mark_minimizer(name="scipy_lbfgsb")
 def scipy_lbfgsb(

--- a/src/estimagic/optimization/scipy_optimizers.py
+++ b/src/estimagic/optimization/scipy_optimizers.py
@@ -42,6 +42,7 @@ import functools
 
 import numpy as np
 import scipy
+from estimagic.decorators import mark_minimizer
 from estimagic.optimization.algo_options import CONVERGENCE_ABSOLUTE_CRITERION_TOLERANCE
 from estimagic.optimization.algo_options import CONVERGENCE_ABSOLUTE_GRADIENT_TOLERANCE
 from estimagic.optimization.algo_options import CONVERGENCE_ABSOLUTE_PARAMS_TOLERANCE
@@ -67,6 +68,7 @@ DEFAULT_ALGO_INFO = {
 }
 
 
+@mark_minimizer(name="scipy_lbfgsb")
 def scipy_lbfgsb(
     criterion_and_derivative,
     x,
@@ -85,14 +87,6 @@ def scipy_lbfgsb(
     For details see :ref:`list_of_scipy_algorithms`.
 
     """
-    algo_info = DEFAULT_ALGO_INFO.copy()
-    algo_info["name"] = "scipy_lbfgsb"
-    func = functools.partial(
-        criterion_and_derivative,
-        task="criterion_and_derivative",
-        algorithm_info=algo_info,
-    )
-
     options = {
         "maxcor": limited_memory_storage_length,
         "ftol": convergence_relative_criterion_tolerance,
@@ -103,7 +97,7 @@ def scipy_lbfgsb(
     }
 
     res = scipy.optimize.minimize(
-        fun=func,
+        fun=criterion_and_derivative,
         x0=x,
         method="L-BFGS-B",
         jac=True,
@@ -114,8 +108,10 @@ def scipy_lbfgsb(
     return process_scipy_result(res)
 
 
+@mark_minimizer(name="scipy_lbfgsb")
 def scipy_slsqp(
-    criterion_and_derivative,
+    criterion,
+    derivative,
     x,
     lower_bounds,
     upper_bounds,
@@ -128,19 +124,6 @@ def scipy_slsqp(
     For details see :ref:`list_of_scipy_algorithms`.
 
     """
-    algo_info = DEFAULT_ALGO_INFO.copy()
-    algo_info["name"] = "scipy_slsqp"
-
-    func = functools.partial(
-        criterion_and_derivative,
-        task="criterion",
-        algorithm_info=algo_info,
-    )
-
-    gradient = functools.partial(
-        criterion_and_derivative, task="derivative", algorithm_info=algo_info
-    )
-
     options = {
         "maxiter": stopping_max_iterations,
         # this is the absolute criterion tolerance according to
@@ -149,10 +132,10 @@ def scipy_slsqp(
     }
 
     res = scipy.optimize.minimize(
-        fun=func,
+        fun=criterion,
         x0=x,
         method="SLSQP",
-        jac=gradient,
+        jac=derivative,
         bounds=get_scipy_bounds(lower_bounds, upper_bounds),
         options=options,
     )
@@ -160,8 +143,9 @@ def scipy_slsqp(
     return process_scipy_result(res)
 
 
+@mark_minimizer(name="scipy_neldermead", needs_scaling=True)
 def scipy_neldermead(
-    criterion_and_derivative,
+    criterion,
     x,
     *,
     stopping_max_iterations=STOPPING_MAX_ITERATIONS,
@@ -175,13 +159,6 @@ def scipy_neldermead(
     For details see :ref:`list_of_scipy_algorithms`.
 
     """
-    algo_info = DEFAULT_ALGO_INFO.copy()
-    algo_info["name"] = "scipy_neldermead"
-    func = functools.partial(
-        criterion_and_derivative,
-        task="criterion",
-        algorithm_info=algo_info,
-    )
     options = {
         "maxiter": stopping_max_iterations,
         "maxfev": stopping_max_criterion_evaluations,
@@ -193,7 +170,7 @@ def scipy_neldermead(
     }
 
     res = scipy.optimize.minimize(
-        fun=func,
+        fun=criterion,
         x0=x,
         method="Nelder-Mead",
         options=options,
@@ -202,8 +179,9 @@ def scipy_neldermead(
     return process_scipy_result(res)
 
 
+@mark_minimizer(name="scipy_powell", needs_scaling=True)
 def scipy_powell(
-    criterion_and_derivative,
+    criterion,
     x,
     lower_bounds,
     upper_bounds,
@@ -218,14 +196,6 @@ def scipy_powell(
     For details see :ref:`list_of_scipy_algorithms`.
 
     """
-    algo_info = DEFAULT_ALGO_INFO.copy()
-    algo_info["name"] = "scipy_powell"
-    func = functools.partial(
-        criterion_and_derivative,
-        task="criterion",
-        algorithm_info=algo_info,
-    )
-
     options = {
         "xtol": convergence_relative_params_tolerance,
         "ftol": convergence_relative_criterion_tolerance,
@@ -234,7 +204,7 @@ def scipy_powell(
     }
 
     res = scipy.optimize.minimize(
-        fun=func,
+        fun=criterion,
         x0=x,
         method="Powell",
         bounds=get_scipy_bounds(lower_bounds, upper_bounds),
@@ -244,6 +214,7 @@ def scipy_powell(
     return process_scipy_result(res)
 
 
+@mark_minimizer(name="scipy_bfgs")
 def scipy_bfgs(
     criterion_and_derivative,
     x,
@@ -257,17 +228,6 @@ def scipy_bfgs(
     For details see :ref:`list_of_scipy_algorithms`.
 
     """
-    algo_info = DEFAULT_ALGO_INFO.copy()
-    algo_info["name"] = "scipy_bfgs"
-    func = functools.partial(
-        criterion_and_derivative,
-        task="criterion",
-        algorithm_info=algo_info,
-    )
-    gradient = functools.partial(
-        criterion_and_derivative, task="derivative", algorithm_info=algo_info
-    )
-
     options = {
         "gtol": convergence_absolute_gradient_tolerance,
         "maxiter": stopping_max_iterations,
@@ -275,16 +235,17 @@ def scipy_bfgs(
     }
 
     res = scipy.optimize.minimize(
-        fun=func,
+        fun=criterion_and_derivative,
         x0=x,
         method="BFGS",
-        jac=gradient,
+        jac=True,
         options=options,
     )
 
     return process_scipy_result(res)
 
 
+@mark_minimizer(name="scipy_conjugate_gradient")
 def scipy_conjugate_gradient(
     criterion_and_derivative,
     x,
@@ -298,18 +259,6 @@ def scipy_conjugate_gradient(
     For details see :ref:`list_of_scipy_algorithms`.
 
     """
-    algo_info = DEFAULT_ALGO_INFO.copy()
-    algo_info["name"] = "scipy_conjugate_gradient"
-    func = functools.partial(
-        criterion_and_derivative,
-        task="criterion",
-        algorithm_info=algo_info,
-    )
-
-    gradient = functools.partial(
-        criterion_and_derivative, task="derivative", algorithm_info=algo_info
-    )
-
     options = {
         "gtol": convergence_absolute_gradient_tolerance,
         "maxiter": stopping_max_iterations,
@@ -317,16 +266,17 @@ def scipy_conjugate_gradient(
     }
 
     res = scipy.optimize.minimize(
-        fun=func,
+        fun=criterion_and_derivative,
         x0=x,
         method="CG",
-        jac=gradient,
+        jac=True,
         options=options,
     )
 
     return process_scipy_result(res)
 
 
+@mark_minimizer(name="scipy_newton_cg")
 def scipy_newton_cg(
     criterion_and_derivative,
     x,
@@ -339,35 +289,25 @@ def scipy_newton_cg(
     For details see :ref:`list_of_scipy_algorithms`.
 
     """
-    algo_info = DEFAULT_ALGO_INFO.copy()
-    algo_info["name"] = "scipy_newton_cg"
-    func = functools.partial(
-        criterion_and_derivative,
-        task="criterion",
-        algorithm_info=algo_info,
-    )
-    gradient = functools.partial(
-        criterion_and_derivative, task="derivative", algorithm_info=algo_info
-    )
-
     options = {
         "xtol": convergence_relative_params_tolerance,
         "maxiter": stopping_max_iterations,
     }
 
     res = scipy.optimize.minimize(
-        fun=func,
+        fun=criterion_and_derivative,
         x0=x,
         method="Newton-CG",
-        jac=gradient,
+        jac=True,
         options=options,
     )
 
     return process_scipy_result(res)
 
 
+@mark_minimizer(name="scipy_cobyla", needs_scaling=True)
 def scipy_cobyla(
-    criterion_and_derivative,
+    criterion,
     x,
     *,
     stopping_max_iterations=STOPPING_MAX_ITERATIONS,
@@ -379,22 +319,13 @@ def scipy_cobyla(
     For details see :ref:`list_of_scipy_algorithms`.
 
     """
-    algo_info = DEFAULT_ALGO_INFO.copy()
-    algo_info["name"] = "scipy_cobyla"
-
-    func = functools.partial(
-        criterion_and_derivative,
-        task="criterion",
-        algorithm_info=algo_info,
-    )
-
     if trustregion_initial_radius is None:
         trustregion_initial_radius = calculate_trustregion_initial_radius(x)
 
     options = {"maxiter": stopping_max_iterations, "rhobeg": trustregion_initial_radius}
 
     res = scipy.optimize.minimize(
-        fun=func,
+        fun=criterion,
         x0=x,
         method="COBYLA",
         options=options,
@@ -404,6 +335,7 @@ def scipy_cobyla(
     return process_scipy_result(res)
 
 
+@mark_minimizer(name="scipy_truncated_newton")
 def scipy_truncated_newton(
     criterion_and_derivative,
     x,
@@ -427,17 +359,6 @@ def scipy_truncated_newton(
     For details see :ref:`list_of_scipy_algorithms`.
 
     """
-    algo_info = DEFAULT_ALGO_INFO.copy()
-    algo_info["name"] = "scipy_truncated_newton"
-    func = functools.partial(
-        criterion_and_derivative,
-        task="criterion",
-        algorithm_info=algo_info,
-    )
-    gradient = functools.partial(
-        criterion_and_derivative, task="derivative", algorithm_info=algo_info
-    )
-
     options = {
         # scipy/optimize/tnc/tnc.c::809 and 844 show that ftol is the
         # absolute criterion tolerance
@@ -457,10 +378,10 @@ def scipy_truncated_newton(
     }
 
     res = scipy.optimize.minimize(
-        fun=func,
+        fun=criterion_and_derivative,
         x0=x,
         method="TNC",
-        jac=gradient,
+        jac=True,
         options=options,
         bounds=get_scipy_bounds(lower_bounds, upper_bounds),
     )
@@ -468,6 +389,7 @@ def scipy_truncated_newton(
     return process_scipy_result(res)
 
 
+@mark_minimizer(name="scipy_trust_constr")
 def scipy_trust_constr(
     criterion_and_derivative,
     x,
@@ -484,17 +406,6 @@ def scipy_trust_constr(
     For details see :ref:`list_of_scipy_algorithms`.
 
     """
-    algo_info = DEFAULT_ALGO_INFO.copy()
-    algo_info["name"] = "scipy_trust_constr"
-    func = functools.partial(
-        criterion_and_derivative,
-        task="criterion",
-        algorithm_info=algo_info,
-    )
-    gradient = functools.partial(
-        criterion_and_derivative, task="derivative", algorithm_info=algo_info
-    )
-
     if trustregion_initial_radius is None:
         trustregion_initial_radius = calculate_trustregion_initial_radius(x)
 
@@ -503,13 +414,11 @@ def scipy_trust_constr(
         "maxiter": stopping_max_iterations,
         "xtol": convergence_relative_params_tolerance,
         "initial_tr_radius": trustregion_initial_radius,
-        # don't have "grad" here as we already supply the gradient via the "jac"
-        # argument supplied directly to scipy.optimize.minimize.
     }
 
     res = scipy.optimize.minimize(
-        fun=func,
-        jac=gradient,
+        fun=criterion_and_derivative,
+        jac=True,
         x0=x,
         method="trust-constr",
         bounds=get_scipy_bounds(lower_bounds, upper_bounds),
@@ -517,74 +426,6 @@ def scipy_trust_constr(
     )
 
     return process_scipy_result(res)
-
-
-def scipy_ls_trf(
-    criterion_and_derivative,
-    x,
-    lower_bounds,
-    upper_bounds,
-    *,
-    convergence_relative_criterion_tolerance=CONVERGENCE_RELATIVE_CRITERION_TOLERANCE,
-    convergence_relative_gradient_tolerance=CONVERGENCE_RELATIVE_GRADIENT_TOLERANCE,
-    stopping_max_criterion_evaluations=STOPPING_MAX_CRITERION_EVALUATIONS,
-    relative_step_size_diff_approx=None,
-    tr_solver=None,
-    tr_solver_options=None,
-):
-    """
-    Minimize a scalar function using a trust region reflective method.
-
-    For details see :ref:`list_of_scipy_algorithms`.
-
-    """
-    return _scipy_least_squares(
-        criterion_and_derivative,
-        x,
-        lower_bounds,
-        upper_bounds,
-        convergence_relative_criterion_tolerance=convergence_relative_criterion_tolerance,  # noqa: E501
-        convergence_relative_gradient_tolerance=convergence_relative_gradient_tolerance,
-        stopping_max_criterion_evaluations=stopping_max_criterion_evaluations,
-        relative_step_size_diff_approx=relative_step_size_diff_approx,
-        tr_solver=tr_solver,
-        tr_solver_options=tr_solver_options,
-        method="trf",
-    )
-
-
-def scipy_ls_dogbox(
-    criterion_and_derivative,
-    x,
-    lower_bounds,
-    upper_bounds,
-    *,
-    convergence_relative_criterion_tolerance=CONVERGENCE_RELATIVE_CRITERION_TOLERANCE,
-    convergence_relative_gradient_tolerance=CONVERGENCE_RELATIVE_GRADIENT_TOLERANCE,
-    stopping_max_criterion_evaluations=STOPPING_MAX_CRITERION_EVALUATIONS,
-    relative_step_size_diff_approx=None,
-    tr_solver=None,
-    tr_solver_options=None,
-):
-    """
-    Minimize a scalar function using a rectangular trust region method.
-
-    For details see :ref:`list_of_scipy_algorithms`.
-
-    """
-    return _scipy_least_squares(
-        criterion_and_derivative,
-        x,
-        lower_bounds,
-        upper_bounds,
-        convergence_relative_criterion_tolerance=convergence_relative_criterion_tolerance,  # noqa: E501
-        convergence_relative_gradient_tolerance=convergence_relative_gradient_tolerance,
-        stopping_max_criterion_evaluations=stopping_max_criterion_evaluations,
-        relative_step_size_diff_approx=relative_step_size_diff_approx,
-        tr_solver=tr_solver,
-        tr_solver_options=tr_solver_options,
-        method="dogbox",
-    )
 
 
 def process_scipy_result(scipy_results_obj):
@@ -616,7 +457,8 @@ def get_scipy_bounds(lower_bounds, upper_bounds):
 
 
 def _scipy_least_squares(
-    criterion_and_derivative,
+    criterion,
+    derivative,
     x,
     lower_bounds,
     upper_bounds,
@@ -639,29 +481,63 @@ def _scipy_least_squares(
     if tr_solver_options is None:
         tr_solver_options = {}
 
-    algo_info = DEFAULT_ALGO_INFO.copy()
-    algo_info["name"] = f"scipy_ls_{method}"
-    algo_info["primary_criterion_entry"] = "root_contributions"
-    func = functools.partial(
-        criterion_and_derivative,
-        task="criterion",
-        algorithm_info=algo_info,
-    )
-
-    gradient = functools.partial(
-        criterion_and_derivative, task="derivative", algorithm_info=algo_info
-    )
-
     res = scipy.optimize.least_squares(
-        fun=func,
+        fun=criterion,
         x0=x,
-        jac=gradient,
+        jac=derivative,
         # Don't use get_scipy_bounds, b.c. least_squares uses np.inf
         bounds=(lower_bounds, upper_bounds),
         max_nfev=stopping_max_criterion_evaluations,
         ftol=convergence_relative_criterion_tolerance,
         gtol=convergence_relative_gradient_tolerance,
         method=method,
+        diff_step=relative_step_size_diff_approx,
+        tr_solver=tr_solver,
+        tr_options=tr_solver_options,
+    )
+
+    return process_scipy_result(res)
+
+
+_scipy_ls_trf = functools.partial(_scipy_least_squares, method="trf")
+scipy_ls_trf = mark_minimizer(
+    _scipy_ls_trf, name="scipy_ls_trf", primary_criterion_entry="root_contributions"
+)
+
+_scipy_ls_dogbox = functools.partial(_scipy_least_squares, method="dogbox")
+scipy_ls_dogbox = mark_minimizer(
+    _scipy_ls_dogbox,
+    name="scipy_ls_dogbox",
+    primary_criterion_entry="root_contributions",
+)
+
+
+@mark_minimizer(name="scipy_ls_lm", primary_criterion_entry="root_contributions")
+def scipy_ls_lm(
+    criterion,
+    derivative,
+    x,
+    *,
+    convergence_relative_criterion_tolerance=CONVERGENCE_RELATIVE_CRITERION_TOLERANCE,
+    convergence_relative_gradient_tolerance=CONVERGENCE_RELATIVE_GRADIENT_TOLERANCE,
+    stopping_max_criterion_evaluations=STOPPING_MAX_CRITERION_EVALUATIONS,
+    relative_step_size_diff_approx=None,
+    tr_solver=None,
+    tr_solver_options=None,
+):
+    """Internal function used by the scipy_ls_trf and scipy_ls_dogbox functions."""
+
+    if tr_solver_options is None:
+        tr_solver_options = {}
+
+    res = scipy.optimize.least_squares(
+        fun=criterion,
+        x0=x,
+        jac=derivative,
+        max_nfev=stopping_max_criterion_evaluations,
+        ftol=convergence_relative_criterion_tolerance,
+        gtol=convergence_relative_gradient_tolerance,
+        method="lm",
         diff_step=relative_step_size_diff_approx,
         tr_solver=tr_solver,
         tr_options=tr_solver_options,

--- a/src/estimagic/optimization/tao_optimizers.py
+++ b/src/estimagic/optimization/tao_optimizers.py
@@ -4,6 +4,7 @@ import functools
 import numpy as np
 from estimagic.config import IS_PETSC4PY_INSTALLED
 from estimagic.decorators import mark_minimizer
+from estimagic.exceptions import NotInstalledError
 from estimagic.optimization.algo_options import CONVERGENCE_ABSOLUTE_GRADIENT_TOLERANCE
 from estimagic.optimization.algo_options import CONVERGENCE_RELATIVE_GRADIENT_TOLERANCE
 from estimagic.optimization.algo_options import CONVERGENCE_SCALED_GRADIENT_TOLERANCE
@@ -39,10 +40,11 @@ def tao_pounders(
     For details see :ref:`tao_algorithm`.
     """
     if not IS_PETSC4PY_INSTALLED:
-        raise NotImplementedError(
-            "The petsc4py package is not installed and required for 'tao_pounders'. If "
-            "you are using Linux or MacOS, install the package with 'conda install -c "
-            "conda-forge petsc4py. The package is not available on Windows."
+        raise NotInstalledError(
+            "The 'tao_pounders' algorithm requires the petsc4py package to be "
+            "installed. If you are using Linux or MacOS, install the package with "
+            "'conda install -c conda-forge petsc4py. The package is not available on "
+            "Windows. Windows users can use estimagics 'pounders' algorithm instead."
         )
 
     x = _initialise_petsc_array(x)

--- a/src/estimagic/optimization/tiktak.py
+++ b/src/estimagic/optimization/tiktak.py
@@ -17,6 +17,7 @@ import numpy as np
 from chaospy.distributions import Triangle
 from chaospy.distributions import Uniform
 from estimagic import batch_evaluators as be
+from estimagic.decorators import AlgoInfo
 from estimagic.optimization.optimization_logging import log_scheduled_steps_and_get_ids
 from estimagic.optimization.optimization_logging import update_step_status
 from estimagic.parameters.parameter_conversion import get_internal_bounds
@@ -24,7 +25,7 @@ from estimagic.parameters.parameter_conversion import get_internal_bounds
 
 def run_multistart_optimization(
     local_algorithm,
-    criterion_and_derivative,
+    problem_functions,
     x,
     lower_bounds,
     upper_bounds,
@@ -62,8 +63,13 @@ def run_multistart_optimization(
             db_kwargs=db_kwargs,
         )
 
+    if "criterion" in problem_functions:
+        criterion = problem_functions["criterion"]
+    else:
+        criterion = partial(list(problem_functions.values())[0], task="criterion")
+
     exploration_res = run_explorations(
-        criterion_and_derivative,
+        criterion,
         sample=sample,
         batch_evaluator=options["batch_evaluator"],
         n_cores=options["n_cores"],
@@ -124,11 +130,10 @@ def run_multistart_optimization(
         "max_discoveries": options["convergence_max_discoveries"],
     }
 
-    criterion_and_derivative = partial(
-        criterion_and_derivative,
-        error_handling=error_handling,
-        error_penalty=error_penalty,
-    )
+    problem_functions = {
+        name: partial(func, error_handling=error_handling, error_penalty=error_penalty)
+        for name, func in problem_functions.items()
+    }
 
     batch_evaluator = options["batch_evaluator"]
 
@@ -145,14 +150,14 @@ def run_multistart_optimization(
         starts = [weight * state["best_x"] + (1 - weight) * x for x in batch]
 
         arguments = [
-            (criterion_and_derivative, x, step)
+            {**problem_functions, "x": x, "step_id": step}
             for x, step in zip(starts, scheduled_steps)
         ]
 
         batch_results = batch_evaluator(
             func=local_algorithm,
             arguments=arguments,
-            unpack_symbol="*",
+            unpack_symbol="**",
             n_cores=options["n_cores"],
             error_handling=options["optimization_error_handling"],
         )
@@ -330,7 +335,7 @@ def run_explorations(func, sample, batch_evaluator, n_cores, step_id, error_hand
     Args:
         func (callable): An already partialled version of
             ``internal_criterion_and_derivative_template`` where the following arguments
-            are still free: ``x``, ``task``, ``algorithm_info``, ``error_handling``,
+            are still free: ``x``, ``task``, ``algo_info``, ``error_handling``,
             ``error_penalty``, ``fixed_log_data``.
         sample (numpy.ndarray): 2d numpy array where each row is a sampled internal
             parameter vector.
@@ -351,17 +356,19 @@ def run_explorations(func, sample, batch_evaluator, n_cores, step_id, error_hand
                 entries of the function evaluations.
 
     """
-    algo_info = {
-        "primary_criterion_entry": "dict",
-        "parallelizes": True,
-        "needs_scaling": False,
-        "name": "tiktak_explorer",
-    }
+    algo_info = AlgoInfo(
+        primary_criterion_entry="dict",
+        parallelizes=True,
+        needs_scaling=False,
+        name="tiktak_explorer",
+        disable_cache=True,
+        is_available=True,
+    )
 
     _func = partial(
         func,
         task="criterion",
-        algorithm_info=algo_info,
+        algo_info=algo_info,
         error_handling=error_handling,
         error_penalty={"constant": np.nan, "slope": np.nan},
     )

--- a/tests/optimization/test_bhhh.py
+++ b/tests/optimization/test_bhhh.py
@@ -61,71 +61,39 @@ def get_score_probit(endog, exog, x):
     return derivative_loglikelihood[:, None] * exog
 
 
-def criterion_and_derivative_logit(x, task="criterion_and_derivative"):
+def criterion_and_derivative_logit(x):
     """Return Logit criterion and derivative.
 
     Args:
         x (np.ndarray): Parameter vector of shape (n_obs,).
-        task (str): If task=="criterion", compute log-likelihood.
-            If task=="derivative", compute derivative.
-            If task="criterion_and_derivative", compute both.
 
     Returns:
-        (np.ndarray or tuple): If task=="criterion" it returns the output of
-            criterion, which is a 1d numpy array.
-            If task=="derivative" it returns the first derivative of criterion,
-            which is a numpy array.
-            If task=="criterion_and_derivative" it returns both as a tuple.
+        tuple: first entry is the criterion, second entry is the score
+
     """
     endog, exog = generate_test_data()
     score = partial(get_score_logit, endog, exog)
     loglike = partial(get_loglikelihood_logit, endog, exog)
 
-    result = ()
-
-    if "criterion" in task:
-        result += (-loglike(x),)
-    if "derivative" in task:
-        result += (score(x),)
-
-    if len(result) == 1:
-        (result,) = result
-
-    return result
+    return -loglike(x), score(x)
 
 
-def criterion_and_derivative_probit(x, task="criterion_and_derivative"):
+def criterion_and_derivative_probit(x):
     """Return Probit criterion and derivative.
 
     Args:
         x (np.ndarray): Parameter vector of shape (n_obs,).
-        task (str): If task=="criterion", compute log-likelihood.
-            If task=="derivative", compute derivative.
-            If task="criterion_and_derivative", compute both.
 
     Returns:
-        (np.ndarray or tuple): If task=="criterion" it returns the output of
-            criterion, which is a 1d numpy array.
-            If task=="derivative" it returns the first derivative of criterion,
-            which is a numpy array.
-            If task=="criterion_and_derivative" it returns both as a tuple.
+        tuple: first entry is the criterion, second entry is the score
+
     """
     endog, exog = generate_test_data()
 
     score = partial(get_score_probit, endog, exog)
     loglike = partial(get_loglikelihood_probit, endog, exog)
 
-    result = ()
-
-    if "criterion" in task:
-        result += (-loglike(x),)
-    if "derivative" in task:
-        result += (score(x),)
-
-    if len(result) == 1:
-        (result,) = result
-
-    return result
+    return -loglike(x), score(x)
 
 
 @pytest.fixture
@@ -157,7 +125,7 @@ def test_maximum_likelihood(criterion_and_derivative, result_statsmodels, reques
     x = np.zeros(3)
 
     result_bhhh = bhhh_internal(
-        criterion_and_derivative=criterion_and_derivative,
+        criterion_and_derivative,
         x=x,
         convergence_absolute_gradient_tolerance=1e-8,
         stopping_max_iterations=200,

--- a/tests/optimization/test_fides_options.py
+++ b/tests/optimization/test_fides_options.py
@@ -39,15 +39,8 @@ test_cases_no_contribs_needed = [
 ]
 
 
-def criterion_and_derivative(x, task, algorithm_info):
-    if task == "criterion":
-        return (x**2).sum()
-    elif task == "derivative":
-        return 2 * x
-    elif task == "criterion_and_derivative":
-        return (x**2).sum(), 2 * x
-    else:
-        raise ValueError(f"Unknown task: {task}")
+def criterion_and_derivative(x):
+    return (x**2).sum(), 2 * x
 
 
 @pytest.mark.skipif(not IS_FIDES_INSTALLED, reason="fides not installed.")

--- a/tests/optimization/test_internal_criterion_and_derivative_template.py
+++ b/tests/optimization/test_internal_criterion_and_derivative_template.py
@@ -4,6 +4,7 @@ import itertools
 import numpy as np
 import pandas as pd
 import pytest
+from estimagic.decorators import AlgoInfo
 from estimagic.differentiation.derivatives import first_derivative
 from estimagic.examples.criterion_functions import sos_criterion_and_gradient
 from estimagic.examples.criterion_functions import sos_dict_criterion
@@ -66,12 +67,14 @@ def base_inputs():
         "params": params,
         "reparametrize_from_internal": reparametrize_from_internal,
         "convert_derivative": convert_derivative,
-        "algorithm_info": {
-            "primary_criterion_entry": "value",
-            "parallelizes": False,
-            "needs_scaling": False,
-            "name": "my_algorithm",
-        },
+        "algo_info": AlgoInfo(
+            name="my_algorithm",
+            primary_criterion_entry="value",
+            parallelizes=False,
+            needs_scaling=False,
+            disable_cache=False,
+            is_available=True,
+        ),
         "numdiff_options": {},
         "logging": False,
         "db_kwargs": {"database": False, "fast_logging": False, "path": "logging.db"},

--- a/tests/optimization/test_ipopt_options.py
+++ b/tests/optimization/test_ipopt_options.py
@@ -196,20 +196,20 @@ test_cases = [
 ]
 
 
-def criterion_and_derivative(x, task, algorithm_info):
-    if task == "criterion":
-        return (x**2).sum()
-    elif task == "derivative":
-        return 2 * x
-    else:
-        raise ValueError(f"Unknown task: {task}")
+def criterion(x):
+    return (x**2).sum()
+
+
+def derivative(x):
+    return 2 * x
 
 
 @pytest.mark.skipif(not IS_CYIPOPT_INSTALLED, reason="cyipopt not installed.")
 @pytest.mark.parametrize("algo_options", test_cases)
 def test_ipopt_algo_options(algo_options):
     res = ipopt(
-        criterion_and_derivative=criterion_and_derivative,
+        criterion=criterion,
+        derivative=derivative,
         x=np.array([1, 2, 3]),
         lower_bounds=np.array([-np.inf, -np.inf, -np.inf]),
         upper_bounds=np.array([np.inf, np.inf, np.inf]),

--- a/tests/optimization/test_neldermead.py
+++ b/tests/optimization/test_neldermead.py
@@ -11,7 +11,6 @@ from estimagic.optimization.neldermead import neldermead_parallel
 
 # function to test
 def sphere(x, *args, **kwargs):
-
     return (x**2).sum()
 
 
@@ -121,7 +120,7 @@ test_cases = [
 @pytest.mark.parametrize("algo_options", test_cases)
 def test_neldermead_correct_algo_options(algo_options):
     res = neldermead_parallel(
-        criterion_and_derivative=sphere,
+        criterion=sphere,
         x=np.array([1, -5, 3]),
         **algo_options,
     )
@@ -131,7 +130,7 @@ def test_neldermead_correct_algo_options(algo_options):
 # test if maximum number of iterations works
 def test_fides_stop_after_one_iteration():
     res = neldermead_parallel(
-        criterion_and_derivative=sphere,
+        criterion=sphere,
         x=np.array([1, -5, 3]),
         stopping_max_iterations=1,
     )

--- a/tests/optimization/test_tiktak.py
+++ b/tests/optimization/test_tiktak.py
@@ -85,7 +85,7 @@ def test_run_explorations():
     def _dummy(x, **kwargs):
         assert set(kwargs) == {
             "task",
-            "algorithm_info",
+            "algo_info",
             "error_handling",
             "error_penalty",
             "fixed_log_data",

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -2,6 +2,7 @@ import numpy as np
 import pandas as pd
 import pytest
 from estimagic.decorators import catch
+from estimagic.decorators import mark_minimizer
 from estimagic.decorators import numpy_interface
 from estimagic.decorators import unpack
 from numpy.testing import assert_array_almost_equal as aaae
@@ -94,3 +95,23 @@ def test_unpack_decorator_two_stars():
         return x + y
 
     assert f({"x": 3, "y": 4}) == 7
+
+
+def test_mark_minimizer_decorator():
+    @mark_minimizer(name="bla")
+    def minimize_stupid():
+        pass
+
+    assert hasattr(minimize_stupid, "_algorithm_info")
+    assert minimize_stupid._algorithm_info.name == "bla"
+
+
+def test_mark_minimizer_direct_call():
+    def minimize_stupid():
+        pass
+
+    first = mark_minimizer(minimize_stupid, name="bla")
+    second = mark_minimizer(minimize_stupid, name="blubb")
+
+    assert first._algorithm_info.name == "bla"
+    assert second._algorithm_info.name == "blubb"

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -1,13 +1,6 @@
 import numpy as np
 import pandas as pd
 import pytest
-from estimagic.config import IS_CYIPOPT_INSTALLED
-from estimagic.config import IS_DFOLS_INSTALLED
-from estimagic.config import IS_FIDES_INSTALLED
-from estimagic.config import IS_PETSC4PY_INSTALLED
-from estimagic.config import IS_PYBOBYQA_INSTALLED
-from estimagic.config import IS_PYGMO_INSTALLED
-from estimagic.optimization import AVAILABLE_ALGORITHMS
 from estimagic.utilities import calculate_trustregion_initial_radius
 from estimagic.utilities import chol_params_to_lower_triangular_matrix
 from estimagic.utilities import cov_matrix_to_params
@@ -173,15 +166,3 @@ def test_initial_trust_radius_large_x():
     expected = 2.05
     res = calculate_trustregion_initial_radius(x)
     assert expected == pytest.approx(res, abs=1e-8)
-
-
-def test_available_algorithms():
-    present_algo_names = AVAILABLE_ALGORITHMS.keys()
-    assert "scipy_lbfgsb" in present_algo_names
-    assert ("nag_dfols" in present_algo_names) is IS_DFOLS_INSTALLED
-    assert ("tao_pounders" in present_algo_names) is IS_PETSC4PY_INSTALLED
-    assert ("nag_pybobyqa" in present_algo_names) is IS_PYBOBYQA_INSTALLED
-    assert ("pygmo_gaco" in present_algo_names) is IS_PYGMO_INSTALLED
-    assert ("ipopt" in present_algo_names) is IS_CYIPOPT_INSTALLED
-    assert ("fides" in present_algo_names) is IS_FIDES_INSTALLED
-    assert "get_scipy_bounds" not in present_algo_names


### PR DESCRIPTION
## Problem

The internal optimizer interface is flexible but relies on two unintuitive concepts (algorithm_info and partialling a "task"). Moreover, collecting algorithms is difficult and requires many if conditions. 

## Solution

- The `mark_minimizer` decorator replaces the algorithm_info and also makes the collection of algorithms much simpler
- Instead of having `criterion_and_derivative` as argument in all algorithms, algorithms can now take `criterion`, `derivative`, `criterion_and_derivative` or any subset of those three as arguments. 

## To-Do 

- [x] Implement new interface
- [x] Convert internal algorithms to new interface
    - [x] scipy
    - [x] nag
    - [x] tao
    - [x] pygmo
    - [x] nlopt (partial approach similar to scipy least squares should be possible for some local optimizers)
    - [x] ipopt
    - [x] fides
    - [x] bhh
    - [x] pounders
    - [x] parallel neldermead
