### PR TITLE
Remove chaospy dependency

### DIFF
--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -36,7 +36,6 @@ requirements:
     - sqlalchemy >=1.3
     - seaborn
     - dill
-    - chaospy
     - pybaum
 
 test:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,11 @@ chronological order. We follow `semantic versioning <https://semver.org/>`_ and 
 releases are available on `Anaconda.org
 <https://anaconda.org/OpenSourceEconomics/estimagic>`_.
 
+0.2.4
+-----
+
+- :gh:`304` Removes the chaospy dependency (:ghuser:`segsell`).
+
 0.2.3
 -----
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -70,7 +70,6 @@ autodoc_mock_imports = [
     "tornado",
     "petsc4py",
     "statsmodels",
-    "chaospy",
 ]
 
 extlinks = {

--- a/docs/source/development/styleguide.rst
+++ b/docs/source/development/styleguide.rst
@@ -121,6 +121,4 @@ Styleguide for the documentation
 
 - Format.
     The code formatting in .rst files is ensured by blacken-docs. For Jupyter
-    notebooks, use the
-    `jupyterlab-code-formatter <https://jupyterlab-code-formatter.readthedocs.io/en/latest/>`_
-    with the black formatter.
+    notebooks, use the jupyterlab-code-formatter with the black formatter.

--- a/environment.yml
+++ b/environment.yml
@@ -42,7 +42,6 @@ dependencies:
   - nlopt
   - sphinx-panels
   - pygmo
-  - chaospy
   - nb_black
   - pybaum
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,7 +59,6 @@ install_requires =
     sqlalchemy>=1.3
     seaborn
     dill
-    chaospy
 
 
 [options.packages.find]

--- a/src/estimagic/optimization/optimize.py
+++ b/src/estimagic/optimization/optimize.py
@@ -838,7 +838,7 @@ def _fill_multistart_options_with_defaults(options, params, x, params_to_interna
         "n_samples": 10 * len(x),
         "share_optimizations": 0.1,
         "sampling_distribution": "uniform",
-        "sampling_method": "sobol" if len(x) <= 30 else "random",
+        "sampling_method": "sobol" if len(x) <= 200 else "random",
         "mixing_weight_method": "tiktak",
         "mixing_weight_bounds": (0.1, 0.995),
         "convergence_relative_params_tolerance": 0.01,

--- a/src/estimagic/optimization/tiktak.py
+++ b/src/estimagic/optimization/tiktak.py
@@ -7,7 +7,6 @@ searches from a set of carefully-selected points in the parameter space.
 
 First implemented in Python by Alisdair McKay
 (`GitHub Repository <https://github.com/amckay/TikTak>`_)
-
 """
 import warnings
 from functools import partial
@@ -220,7 +219,7 @@ def determine_steps(n_samples, n_optimizations):
     return steps
 
 
-def draw_exploration_sample(
+def draw_exploration_sample_chaospy(
     x,
     lower,
     upper,
@@ -233,25 +232,6 @@ def draw_exploration_sample(
 
     The sample is created randomly or using low a low discrepancy sequence. Different
     distributions are available.
-
-    Args:
-        x (np.ndarray): Internal parameter vector,
-        lower (np.ndarray): Vector of internal lower bounds.
-        upper (np.ndarray): Vector of internal upper bounts.
-        n_samples (int): Number of sampled points on
-            which to do one function evaluation. Default is 10 * n_params.
-        sampling_distribution (str): One of "uniform", "triangle". Default is
-            "uniform" as in the original tiktak algorithm.
-        sampling_method (str): One of "random", "sobol", "halton",
-            "hammersley", "korobov", "latin_hypercube" and "chebyshev" or a numpy array
-            or DataFrame with custom points. Default is sobol for problems with up to 30
-            parameters and random for problems with more than 30 parameters.
-        seed (int): Random seed.
-
-    Returns:
-        np.ndarray: Numpy array of shape n_samples, len(params). Each row is a vector
-            of parameter values.
-
     """
     valid_rules = [
         "random",
@@ -285,7 +265,7 @@ def draw_exploration_sample(
     return sample
 
 
-def draw_exploration_sample_scipy(
+def draw_exploration_sample(
     x,
     lower,
     upper,
@@ -296,10 +276,27 @@ def draw_exploration_sample_scipy(
 ):
     """Get a sample of parameter values for the first stage of the tiktak algorithm.
 
-    The sample is created randomly or using low a low discrepancy sequence. Different
+    The sample is created randomly or using a low discrepancy sequence. Different
     distributions are available.
+
+    Args:
+        x (np.ndarray): Internal parameter vector,
+        lower (np.ndarray): Vector of internal lower bounds.
+        upper (np.ndarray): Vector of internal upper bounds.
+        n_samples (int): Number of sampled points on
+            which to do one function evaluation. Default is 10 * n_params.
+        sampling_distribution (str): One of "uniform", "triangle". Default is
+            "uniform", as in the original tiktak algorithm.
+        sampling_method (str): One of "sobol", "halton", "latin_hypercube" or
+            "random". Default is sobol for problems with up to 30 parameters
+            and random for problems with more than 30 parameters.
+        seed (int): Random seed.
+
+    Returns:
+        (np.ndarray): Numpy array of shape (n_samples, len(params)).
+            Each row is a vector of parameter values.
     """
-    valid_rules = ["sobol"]
+    valid_rules = ["sobol", "halton", "latin_hypercube", "random"]
     valid_distributions = ["uniform", "triangle"]
 
     if sampling_method not in valid_rules:
@@ -310,24 +307,34 @@ def draw_exploration_sample_scipy(
     if sampling_distribution not in valid_distributions:
         raise ValueError(f"Unsupported distribution: {sampling_distribution}")
 
-    sampler = qmc.Sobol(d=len(lower), scramble=False, seed=seed)
+    if sampling_method == "sobol":
+        # Draw `n` points from the open interval (lower, upper)^d.
+        # Note that scipy uses the half-open interval [lower, upper)^d internally.
+        # We apply a burn-in phase of 1, i.e. we skip the first point in the sequence
+        # and thus exclude the lower bound.
+        sampler = qmc.Sobol(d=len(lower), scramble=False, seed=seed)
+        _ = sampler.fast_forward(1)
+        sample_unscaled = sampler.random(n=n_samples)
 
-    # Draw `n` points from the open interval (lower, upper)^d.
-    # Since scipy uses the half-open interval [lower, upper)^d internally,
-    # we need to skip the first point in the sequence, i.e. the lower bound.
-    _ = sampler.fast_forward(1)
+    elif sampling_method == "halton":
+        sampler = qmc.Halton(d=len(lower), scramble=False, seed=seed)
+        sample_unscaled = sampler.random(n=n_samples)
 
-    sample_unscaled = sampler.random(n=n_samples)
+    elif sampling_method == "latin_hypercube":
+        sampler = qmc.LatinHypercube(d=len(lower), strength=1, seed=seed)
+        sample_unscaled = sampler.random(n=n_samples)
+
+    elif sampling_method == "random":
+        np.random.seed(seed)
+        sample_unscaled = np.random.sample(size=(n_samples, len(lower)))
 
     if sampling_distribution == "uniform":
         sample_scaled = qmc.scale(sample_unscaled, lower, upper)
-
     elif sampling_distribution == "triangle":
+        # Apply inverse transform sampling to get the desired target distribution
         # https://en.wikipedia.org/wiki/Triangular_distribution
-        treshold = (x - lower) / (upper - lower)
-
         sample_scaled = np.where(
-            sample_unscaled < treshold,
+            sample_unscaled < (x - lower) / (upper - lower),
             lower + np.sqrt(sample_unscaled * (upper - lower) * (x - lower)),
             upper - np.sqrt((1 - sample_unscaled) * (upper - lower) * (upper - x)),
         )

--- a/src/estimagic/optimization/tiktak.py
+++ b/src/estimagic/optimization/tiktak.py
@@ -197,7 +197,6 @@ def determine_steps(n_samples, n_optimizations):
 
     Returns:
         list: List of dictionaries with information on each step.
-
     """
     exploration_step = {
         "type": "exploration",
@@ -236,7 +235,7 @@ def draw_exploration_sample(
         lower (np.ndarray): Vector of internal lower bounds.
         upper (np.ndarray): Vector of internal upper bounds.
         n_samples (int): Number of sample points on which to perform the
-             function evaluation.
+             function evaluation. Default is 10 * n_params.
         sampling_distribution (str): One of "uniform", "triangle". Default is
             "uniform", as in the original tiktak algorithm.
         sampling_method (str): One of "sobol", "halton", "latin_hypercube" or
@@ -245,7 +244,7 @@ def draw_exploration_sample(
         seed (int): Random seed.
 
     Returns:
-        (np.ndarray): Numpy array of shape (n_samples, len(params)).
+        np.ndarray: Numpy array of shape (n_samples, len(params)).
             Each row is a vector of parameter values.
     """
     valid_rules = ["sobol", "halton", "latin_hypercube", "random"]

--- a/src/estimagic/optimization/tiktak.py
+++ b/src/estimagic/optimization/tiktak.py
@@ -231,21 +231,21 @@ def draw_exploration_sample(
     distributions are available.
 
     Args:
-        x (np.ndarray): Internal parameter vector,
-        lower (np.ndarray): Vector of internal lower bounds.
-        upper (np.ndarray): Vector of internal upper bounds.
-        n_samples (int): Number of sample points on which to perform the
-             function evaluation. Default is 10 * n_params.
+        x (np.ndarray): Internal parameter vector of shape (n_params,).
+        lower (np.ndarray): Vector of internal lower bounds of shape (n_params,).
+        upper (np.ndarray): Vector of internal upper bounds of shape (n_params,).
+        n_samples (int): Number of sample points on which one function evaluation
+            shall be performed. Default is 10 * n_params.
         sampling_distribution (str): One of "uniform", "triangular". Default is
             "uniform", as in the original tiktak algorithm.
         sampling_method (str): One of "sobol", "halton", "latin_hypercube" or
-            "random". Default is sobol for problems with up to 30 parameters
-            and random for problems with more than 30 parameters.
+            "random". Default is sobol for problems with up to 200 parameters
+            and random for problems with more than 200 parameters.
         seed (int): Random seed.
 
     Returns:
-        np.ndarray: Numpy array of shape (n_samples, len(params)).
-            Each row is a vector of parameter values.
+        np.ndarray: Numpy array of shape (n_samples, n_params).
+            Each row represents a vector of parameter values.
     """
     valid_rules = ["sobol", "halton", "latin_hypercube", "random"]
     valid_distributions = ["uniform", "triangular"]

--- a/src/estimagic/optimization/tiktak.py
+++ b/src/estimagic/optimization/tiktak.py
@@ -236,7 +236,7 @@ def draw_exploration_sample(
         upper (np.ndarray): Vector of internal upper bounds.
         n_samples (int): Number of sample points on which to perform the
              function evaluation. Default is 10 * n_params.
-        sampling_distribution (str): One of "uniform", "triangle". Default is
+        sampling_distribution (str): One of "uniform", "triangular". Default is
             "uniform", as in the original tiktak algorithm.
         sampling_method (str): One of "sobol", "halton", "latin_hypercube" or
             "random". Default is sobol for problems with up to 30 parameters
@@ -248,7 +248,7 @@ def draw_exploration_sample(
             Each row is a vector of parameter values.
     """
     valid_rules = ["sobol", "halton", "latin_hypercube", "random"]
-    valid_distributions = ["uniform", "triangle"]
+    valid_distributions = ["uniform", "triangular"]
 
     if sampling_method not in valid_rules:
         raise ValueError(
@@ -281,7 +281,7 @@ def draw_exploration_sample(
 
     if sampling_distribution == "uniform":
         sample_scaled = qmc.scale(sample_unscaled, lower, upper)
-    elif sampling_distribution == "triangle":
+    elif sampling_distribution == "triangular":
         sample_scaled = triang.ppf(
             sample_unscaled,
             c=(x - lower) / (upper - lower),

--- a/tests/optimization/test_tiktak.py
+++ b/tests/optimization/test_tiktak.py
@@ -7,7 +7,6 @@ from estimagic.optimization.optimize import process_multistart_sample
 from estimagic.optimization.tiktak import _linear_weights
 from estimagic.optimization.tiktak import _tiktak_weights
 from estimagic.optimization.tiktak import draw_exploration_sample
-from estimagic.optimization.tiktak import draw_exploration_sample_chaospy
 from estimagic.optimization.tiktak import get_batched_optimization_sample
 from estimagic.optimization.tiktak import get_internal_sampling_bounds
 from estimagic.optimization.tiktak import run_explorations
@@ -50,22 +49,9 @@ test_cases = list(product(distributions, rules, lower, upper))
 
 @pytest.mark.parametrize("dist, rule, lower, upper", test_cases)
 def test_draw_exploration_sample(dist, rule, lower, upper):
-    results_chaospy = []
     results = []
 
     for _ in range(2):
-        results_chaospy.append(
-            draw_exploration_sample_chaospy(
-                x=np.ones_like(lower) * 0.5,
-                lower=lower,
-                upper=upper,
-                n_samples=3,
-                sampling_distribution=dist,
-                sampling_method=rule,
-                seed=1234,
-            )
-        )
-
         results.append(
             draw_exploration_sample(
                 x=np.ones_like(lower) * 0.5,

--- a/tests/optimization/test_tiktak.py
+++ b/tests/optimization/test_tiktak.py
@@ -41,18 +41,18 @@ def test_process_multistart_sample(sample, params):
 
 
 dim = 2
-distributions = ["uniform"]
+distributions = ["uniform", "triangle"]
 rules = ["sobol"]
-lower = [np.zeros(dim), np.ones(dim) * 0.5]
-upper = [np.ones(dim), np.ones(dim) * 0.75]
+lower = [np.zeros(dim), np.ones(dim) * 0.5, -np.ones(dim)]
+upper = [np.ones(dim), np.ones(dim) * 0.75, np.ones(dim) * 2]
 test_cases = list(product(distributions, rules, lower, upper))
 
 
 @pytest.mark.parametrize("dist, rule, lower, upper", test_cases)
 def test_draw_exploration_sample(dist, rule, lower, upper):
-
     results = []
     results_scipy = []
+
     for _ in range(2):
         results.append(
             draw_exploration_sample(

--- a/tests/optimization/test_tiktak.py
+++ b/tests/optimization/test_tiktak.py
@@ -40,7 +40,7 @@ def test_process_multistart_sample(sample, params):
 
 
 dim = 2
-distributions = ["uniform", "triangle"]
+distributions = ["uniform", "triangular"]
 rules = ["sobol", "halton", "latin_hypercube", "random"]
 lower = [np.zeros(dim), np.ones(dim) * 0.5, -np.ones(dim)]
 upper = [np.ones(dim), np.ones(dim) * 0.75, np.ones(dim) * 2]

--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,6 @@ conda_deps =
     cyipopt
     nlopt
     pygmo
-    chaospy
     pybaum
 commands = pytest {posargs}
 

--- a/tox.ini
+++ b/tox.ini
@@ -74,7 +74,6 @@ conda_deps =
     cyipopt
     nlopt
     pygmo
-    chaospy
     pybaum
     jax
 commands = pytest {posargs}


### PR DESCRIPTION
In this PR, we get rid of the `chaospy` dependency and rewrite the function [`draw_exporation_sample()`](https://github.com/OpenSourceEconomics/estimagic/blob/7484225bb7e86d28c4ab6a933a1c86943878f493/src/estimagic/optimization/tiktak.py#L222). 

As an alternative to the sampling schemes provided by `chaospy`, we make use of `scipy`'s [Quasi-Monte Carlo module](https://scipy.github.io/devdocs/reference/stats.qmc.html), which offers support for low discrepancy sequences.

To-Do
- [x] Implement sampling schemes provided by scipy's QMC module
    - [x] Sobol
    - [x] Halton
    - [x] Latin hypercube
    - [x] Random
- [x] Add support for the following sampling distributions:
    - [x] Uniform
    - [x] Triangular