### PR TITLE
Collect histories and add them to output of optimization

### DIFF
--- a/src/estimagic/batch_evaluators.py
+++ b/src/estimagic/batch_evaluators.py
@@ -124,7 +124,10 @@ def joblib_batch_evaluator(
     def internal_func(*args, **kwargs):
         return func(*args, **kwargs)
 
-    res = Parallel(n_jobs=n_cores)(delayed(internal_func)(arg) for arg in arguments)
+    if n_cores == 1:
+        res = [internal_func(arg) for arg in arguments]
+    else:
+        res = Parallel(n_jobs=n_cores)(delayed(internal_func)(arg) for arg in arguments)
 
     return res
 

--- a/src/estimagic/decorators.py
+++ b/src/estimagic/decorators.py
@@ -143,7 +143,6 @@ class AlgoInfo(NamedTuple):
     primary_criterion_entry: str
     name: str
     parallelizes: bool
-    disable_cache: bool
     needs_scaling: bool
     is_available: bool
 
@@ -154,7 +153,6 @@ def mark_minimizer(
     primary_criterion_entry="value",
     name=None,
     parallelizes=False,
-    disable_cache=False,
     needs_scaling=False,
     is_available=True,
 ):
@@ -169,8 +167,6 @@ def mark_minimizer(
         name (str): The name of the internal algorithm.
         parallelizes (bool): Must be True if an algorithm evaluates the criterion,
             derivative or criterion_and_derivative in parallel.
-        disable_cache (bool): If True, no caching for the criterion function
-            or its derivatives are used.
         needs_scaling (bool): Must be True if the algorithm is not reasonable
             independent of the scaling of the parameters.
         is_available (bool): Whether the algorithm is available. This is needed for
@@ -194,9 +190,6 @@ def mark_minimizer(
     if not isinstance(parallelizes, bool):
         raise TypeError("parallelizes must be a bool.")
 
-    if not isinstance(disable_cache, bool):
-        raise TypeError("disable_cache must be a bool.")
-
     if not isinstance(needs_scaling, bool):
         raise TypeError("needs_scaling must be a bool.")
 
@@ -207,7 +200,6 @@ def mark_minimizer(
         primary_criterion_entry=primary_criterion_entry,
         name=name,
         parallelizes=parallelizes,
-        disable_cache=disable_cache,
         needs_scaling=needs_scaling,
         is_available=is_available,
     )

--- a/src/estimagic/differentiation/generate_steps.py
+++ b/src/estimagic/differentiation/generate_steps.py
@@ -1,7 +1,12 @@
 import warnings
+from typing import NamedTuple
 
 import numpy as np
-from estimagic.utilities import namedtuple_from_kwargs
+
+
+class Steps(NamedTuple):
+    pos: np.ndarray
+    neg: np.ndarray
 
 
 def generate_steps(
@@ -110,7 +115,7 @@ def generate_steps(
         pos[pos > upper_step_bounds.reshape(-1, 1)] = np.nan
         neg[neg < lower_step_bounds.reshape(-1, 1)] = np.nan
 
-    steps = namedtuple_from_kwargs(pos=pos.T, neg=neg.T)
+    steps = Steps(pos=pos.T, neg=neg.T)
 
     return steps
 

--- a/src/estimagic/optimization/__init__.py
+++ b/src/estimagic/optimization/__init__.py
@@ -36,11 +36,7 @@ for module in MODULES:
                 AVAILABLE_ALGORITHMS[name] = func
 
 
-GLOBAL_ALGORITHMS = [
-    "nlopt_direct",
-    "nlopt_esch",
-    "nlopt_isres",
-    "nlopt_crs2_lm",
-]
-
-GLOBAL_ALGORITHMS += [name for name in AVAILABLE_ALGORITHMS if name.startswith("pygmo")]
+GLOBAL_ALGORITHMS = []
+for name, func in ALL_ALGORITHMS.items():
+    if func._algorithm_info.is_global:
+        GLOBAL_ALGORITHMS.append(name)

--- a/src/estimagic/optimization/bhhh.py
+++ b/src/estimagic/optimization/bhhh.py
@@ -8,7 +8,6 @@ from estimagic.decorators import mark_minimizer
     primary_criterion_entry="contributions",
     parallelizes=False,
     needs_scaling=False,
-    disable_cache=False,
     is_available=True,
 )
 def bhhh(

--- a/src/estimagic/optimization/bhhh.py
+++ b/src/estimagic/optimization/bhhh.py
@@ -6,7 +6,6 @@ from estimagic.decorators import mark_minimizer
 @mark_minimizer(
     name="bhhh",
     primary_criterion_entry="contributions",
-    parallelizes=False,
     needs_scaling=False,
     is_available=True,
 )

--- a/src/estimagic/optimization/cyipopt_optimizers.py
+++ b/src/estimagic/optimization/cyipopt_optimizers.py
@@ -16,7 +16,6 @@ if IS_CYIPOPT_INSTALLED:
     primary_criterion_entry="value",
     parallelizes=False,
     needs_scaling=False,
-    disable_cache=False,
     is_available=IS_CYIPOPT_INSTALLED,
 )
 def ipopt(

--- a/src/estimagic/optimization/cyipopt_optimizers.py
+++ b/src/estimagic/optimization/cyipopt_optimizers.py
@@ -14,7 +14,6 @@ if IS_CYIPOPT_INSTALLED:
 @mark_minimizer(
     name="ipopt",
     primary_criterion_entry="value",
-    parallelizes=False,
     needs_scaling=False,
     is_available=IS_CYIPOPT_INSTALLED,
 )

--- a/src/estimagic/optimization/error_penalty.py
+++ b/src/estimagic/optimization/error_penalty.py
@@ -1,0 +1,118 @@
+from functools import partial
+
+import numpy as np
+from estimagic.config import CRITERION_PENALTY_CONSTANT
+from estimagic.config import CRITERION_PENALTY_SLOPE
+from estimagic.parameters.conversion import aggregate_func_output_to_value
+
+
+def _penalty_value(x, constant, slope, x0, dim_out=None):  # noqa: U100
+    return constant + slope * np.linalg.norm(x - x0)
+
+
+def _penalty_contributions(x, constant, slope, x0, dim_out):
+    contrib = (constant + slope * np.linalg.norm(x - x0)) / dim_out
+    return np.ones(dim_out) * contrib
+
+
+def _penalty_root_contributions(x, constant, slope, x0, dim_out):
+    contrib = np.sqrt((constant + slope * np.linalg.norm(x - x0)) / dim_out)
+    return np.ones(dim_out) * contrib
+
+
+def _penalty_value_derivative(x, constant, slope, x0, dim_out=None):  # noqa: U100
+    return slope * (x - x0) / np.linalg.norm(x - x0)
+
+
+def _penalty_contributions_derivative(x, constant, slope, x0, dim_out):  # noqa: U100
+    row = slope * (x - x0) / (dim_out * np.linalg.norm(x - x0))
+    return np.full((dim_out, len(x)), row)
+
+
+def _penalty_root_contributions_derivative(x, constant, slope, x0, dim_out):
+    inner_deriv = slope * (x - x0) / np.linalg.norm(x - x0)
+    outer_deriv = 0.5 / np.sqrt(_penalty_value(x, constant, slope, x0) * dim_out)
+    row = outer_deriv * inner_deriv
+    return np.full((dim_out, len(x)), row)
+
+
+def get_error_penalty_function(
+    error_handling,
+    start_x,
+    start_criterion,
+    error_penalty,
+    primary_key,
+    direction,
+):
+    if error_handling == "raise":
+        return None
+    elif error_handling != "continue":
+        raise ValueError("Error handling must be 'raise' or 'continue'")
+
+    error_penalty = {} if error_penalty is None else error_penalty
+
+    first_value = aggregate_func_output_to_value(
+        f_eval=start_criterion, primary_key=primary_key
+    )
+
+    constant, slope = _process_error_penalty(
+        error_penalty=error_penalty,
+        first_value=first_value,
+        direction=direction,
+    )
+
+    dim_out = 1 if primary_key == "value" else len(start_criterion)
+
+    kwargs = {"constant": constant, "slope": slope, "x0": start_x, "dim_out": dim_out}
+
+    if primary_key == "value":
+        _penalty = partial(_penalty_value, **kwargs)
+        _derivative = partial(_penalty_value_derivative, **kwargs)
+    elif primary_key == "contributions":
+        _penalty = partial(_penalty_contributions, **kwargs)
+        _derivative = partial(
+            _penalty_contributions_derivative,
+            **kwargs,
+        )
+    elif primary_key == "root_contributions":
+        _penalty = partial(
+            _penalty_root_contributions,
+            **kwargs,
+        )
+        _derivative = partial(_penalty_root_contributions_derivative, **kwargs)
+
+    else:
+        raise ValueError()
+
+    def penalty(x, task):
+        if task == "criterion":
+            out = _penalty(x)
+        elif task == "derivative":
+            out = _derivative(x)
+        elif task == "criterion_and_derivative":
+            out = (_penalty(x), _derivative(x))
+
+        return out
+
+    return penalty
+
+
+def _process_error_penalty(error_penalty, first_value, direction):
+    """Add default options to error_penalty options."""
+    error_penalty = error_penalty.copy()
+
+    if direction == "minimize":
+        default_constant = (
+            first_value + np.abs(first_value) + CRITERION_PENALTY_CONSTANT
+        )
+        default_slope = CRITERION_PENALTY_SLOPE
+    else:
+        default_constant = (
+            first_value - np.abs(first_value) - CRITERION_PENALTY_CONSTANT
+        )
+        default_slope = -CRITERION_PENALTY_SLOPE
+
+    constant = error_penalty.get("constant", default_constant)
+    slope = error_penalty.get("slope", default_slope)
+
+    return constant, slope

--- a/src/estimagic/optimization/fides_optimizers.py
+++ b/src/estimagic/optimization/fides_optimizers.py
@@ -21,7 +21,6 @@ if IS_FIDES_INSTALLED:
     name="fides",
     primary_criterion_entry="value",
     needs_scaling=False,
-    parallelizes=False,
     is_available=IS_FIDES_INSTALLED,
 )
 def fides(

--- a/src/estimagic/optimization/fides_optimizers.py
+++ b/src/estimagic/optimization/fides_optimizers.py
@@ -20,7 +20,6 @@ if IS_FIDES_INSTALLED:
 @mark_minimizer(
     name="fides",
     primary_criterion_entry="value",
-    disable_cache=False,
     needs_scaling=False,
     parallelizes=False,
     is_available=IS_FIDES_INSTALLED,

--- a/src/estimagic/optimization/get_algorithm.py
+++ b/src/estimagic/optimization/get_algorithm.py
@@ -140,6 +140,8 @@ def _add_logging(algorithm=None, *, logging=None, db_kwargs=None):
 
 
 def _add_history_collection(algorithm):
+    """Partial a history container into all functions that define the optimization."""
+
     @functools.wraps(algorithm)
     def wrapper_add_history_collection(**kwargs):
         func_names = {"criterion", "derivative", "criterion_and_derivative"}

--- a/src/estimagic/optimization/get_algorithm.py
+++ b/src/estimagic/optimization/get_algorithm.py
@@ -50,6 +50,7 @@ def get_final_algorithm(
     algo_options,
     logging,
     db_kwargs,
+    collect_history,
 ):
     """Get algorithm-function with partialled options.
 
@@ -89,7 +90,15 @@ def get_final_algorithm(
         db_kwargs=db_kwargs,
     )
 
-    if internal_options.get("n_cores") in (None, 1):
+    can_collect = internal_options.get("n_cores") in (None, 1)
+
+    if not can_collect and collect_history is True:
+        raise ValueError(
+            "Histories can only be collected with optimizers that do not evaluate "
+            "The criterion function or its derivatives in parallel."
+        )
+
+    if can_collect and collect_history is not False:
         algorithm = _add_history_collection(algorithm)
 
     return algorithm

--- a/src/estimagic/optimization/get_algorithm.py
+++ b/src/estimagic/optimization/get_algorithm.py
@@ -1,5 +1,4 @@
 import functools
-import inspect
 import warnings
 from functools import partial
 
@@ -39,13 +38,7 @@ def process_user_algorithm(algorithm):
 
     algo_info = algorithm._algorithm_info
 
-    arguments = set(inspect.signature(algorithm).parameters)
-
-    if isinstance(algorithm, partial):
-        partialed_in = set(algorithm.args).union(set(algorithm.keywords))
-        arguments = arguments.difference(partialed_in)
-
-    return algorithm, algo_info, arguments
+    return algorithm, algo_info
 
 
 def get_final_algorithm(

--- a/src/estimagic/optimization/internal_criterion_template.py
+++ b/src/estimagic/optimization/internal_criterion_template.py
@@ -1,7 +1,6 @@
 import datetime
 import warnings
 
-import numpy as np
 from estimagic.differentiation.derivatives import first_derivative
 from estimagic.exceptions import get_traceback
 from estimagic.exceptions import UserFunctionRuntimeError
@@ -89,7 +88,6 @@ def internal_criterion_and_derivative_template(
             If task=="criterion_and_derivative" it returns both as a tuple.
 
     """
-    x = np.array(x)  # xxxx
     x_hash = hash_array(x)
     cache_entry = cache.get(x_hash, {})
 

--- a/src/estimagic/optimization/internal_criterion_template.py
+++ b/src/estimagic/optimization/internal_criterion_template.py
@@ -50,7 +50,6 @@ def internal_criterion_and_derivative_template(
             - primary_criterion_entry
             - name
             - parallelizes
-            - disable_cache
             - needs_scaling
             - is_available
         derivative (callable, optional): (partialed) user provided function that

--- a/src/estimagic/optimization/nag_optimizers.py
+++ b/src/estimagic/optimization/nag_optimizers.py
@@ -59,7 +59,6 @@ if IS_DFOLS_INSTALLED:
 @mark_minimizer(
     name="nag_dfols",
     primary_criterion_entry="root_contributions",
-    disable_cache=True,
     needs_scaling=True,
     is_available=IS_DFOLS_INSTALLED,
 )
@@ -252,7 +251,6 @@ def nag_dfols(
 
 @mark_minimizer(
     name="nag_dfols",
-    disable_cache=True,
     needs_scaling=True,
     is_available=IS_PYBOBYQA_INSTALLED,
 )

--- a/src/estimagic/optimization/neldermead.py
+++ b/src/estimagic/optimization/neldermead.py
@@ -16,7 +16,6 @@ from estimagic.optimization.algo_options import STOPPING_MAX_ITERATIONS
 @mark_minimizer(
     name="parallel_neldermead",
     primary_criterion_entry="value",
-    parallelizes=True,
     needs_scaling=True,
     is_available=True,
 )

--- a/src/estimagic/optimization/neldermead.py
+++ b/src/estimagic/optimization/neldermead.py
@@ -16,7 +16,6 @@ from estimagic.optimization.algo_options import STOPPING_MAX_ITERATIONS
 @mark_minimizer(
     name="parallel_neldermead",
     primary_criterion_entry="value",
-    disable_cache=False,
     parallelizes=True,
     needs_scaling=True,
     is_available=True,

--- a/src/estimagic/optimization/nlopt_optimizers.py
+++ b/src/estimagic/optimization/nlopt_optimizers.py
@@ -22,7 +22,6 @@ if IS_NLOPT_INSTALLED:
 @mark_minimizer(
     name="nlopt_bobyqa",
     primary_criterion_entry="value",
-    parallelizes=False,
     needs_scaling=False,
     is_available=IS_NLOPT_INSTALLED,
 )
@@ -64,7 +63,6 @@ def nlopt_bobyqa(
 @mark_minimizer(
     name="nlopt_neldermead",
     primary_criterion_entry="value",
-    parallelizes=False,
     needs_scaling=True,
     is_available=IS_NLOPT_INSTALLED,
 )
@@ -106,7 +104,6 @@ def nlopt_neldermead(
 @mark_minimizer(
     name="nlopt_praxis",
     primary_criterion_entry="value",
-    parallelizes=False,
     needs_scaling=True,
     is_available=IS_NLOPT_INSTALLED,
 )
@@ -145,7 +142,6 @@ def nlopt_praxis(
 @mark_minimizer(
     name="nlopt_cobyla",
     primary_criterion_entry="value",
-    parallelizes=False,
     needs_scaling=True,
     is_available=IS_NLOPT_INSTALLED,
 )
@@ -187,7 +183,6 @@ def nlopt_cobyla(
 @mark_minimizer(
     name="nlopt_sbplx",
     primary_criterion_entry="value",
-    parallelizes=False,
     needs_scaling=True,
     is_available=IS_NLOPT_INSTALLED,
 )
@@ -228,7 +223,6 @@ def nlopt_sbplx(
 @mark_minimizer(
     name="nlopt_newuoa",
     primary_criterion_entry="value",
-    parallelizes=False,
     needs_scaling=True,
     is_available=IS_NLOPT_INSTALLED,
 )
@@ -273,7 +267,6 @@ def nlopt_newuoa(
 @mark_minimizer(
     name="nlopt_tnewton",
     primary_criterion_entry="value",
-    parallelizes=False,
     needs_scaling=False,
     is_available=IS_NLOPT_INSTALLED,
 )
@@ -316,7 +309,6 @@ def nlopt_tnewton(
 @mark_minimizer(
     name="nlopt_lbfgsb",
     primary_criterion_entry="value",
-    parallelizes=False,
     needs_scaling=False,
     is_available=IS_NLOPT_INSTALLED,
 )
@@ -359,7 +351,6 @@ def nlopt_lbfgs(
 @mark_minimizer(
     name="nlopt_ccsaq",
     primary_criterion_entry="value",
-    parallelizes=False,
     needs_scaling=False,
     is_available=IS_NLOPT_INSTALLED,
 )
@@ -402,7 +393,6 @@ def nlopt_ccsaq(
 @mark_minimizer(
     name="nlopt_mma",
     primary_criterion_entry="value",
-    parallelizes=False,
     needs_scaling=False,
     is_available=IS_NLOPT_INSTALLED,
 )
@@ -445,7 +435,6 @@ def nlopt_mma(
 @mark_minimizer(
     name="nlopt_var",
     primary_criterion_entry="value",
-    parallelizes=False,
     needs_scaling=False,
     is_available=IS_NLOPT_INSTALLED,
 )
@@ -493,7 +482,6 @@ def nlopt_var(
 @mark_minimizer(
     name="nlopt_slsqp",
     primary_criterion_entry="value",
-    parallelizes=False,
     needs_scaling=False,
     is_available=IS_NLOPT_INSTALLED,
 )
@@ -534,9 +522,9 @@ def nlopt_slsqp(
 @mark_minimizer(
     name="nlopt_direct",
     primary_criterion_entry="value",
-    parallelizes=False,
     needs_scaling=True,
     is_available=IS_NLOPT_INSTALLED,
+    is_global=True,
 )
 def nlopt_direct(
     criterion,
@@ -591,7 +579,7 @@ def nlopt_direct(
 @mark_minimizer(
     name="nlopt_esch",
     primary_criterion_entry="value",
-    parallelizes=False,
+    is_global=True,
     needs_scaling=True,
     is_available=IS_NLOPT_INSTALLED,
 )
@@ -633,7 +621,7 @@ def nlopt_esch(
 @mark_minimizer(
     name="nlopt_isres",
     primary_criterion_entry="value",
-    parallelizes=False,
+    is_global=True,
     needs_scaling=True,
     is_available=IS_NLOPT_INSTALLED,
 )
@@ -675,7 +663,7 @@ def nlopt_isres(
 @mark_minimizer(
     name="nlopt_crs2_lm",
     primary_criterion_entry="value",
-    parallelizes=False,
+    is_global=True,
     needs_scaling=True,
     is_available=IS_NLOPT_INSTALLED,
 )

--- a/src/estimagic/optimization/nlopt_optimizers.py
+++ b/src/estimagic/optimization/nlopt_optimizers.py
@@ -24,7 +24,6 @@ if IS_NLOPT_INSTALLED:
     primary_criterion_entry="value",
     parallelizes=False,
     needs_scaling=False,
-    disable_cache=False,
     is_available=IS_NLOPT_INSTALLED,
 )
 def nlopt_bobyqa(
@@ -67,7 +66,6 @@ def nlopt_bobyqa(
     primary_criterion_entry="value",
     parallelizes=False,
     needs_scaling=True,
-    disable_cache=False,
     is_available=IS_NLOPT_INSTALLED,
 )
 def nlopt_neldermead(
@@ -110,7 +108,6 @@ def nlopt_neldermead(
     primary_criterion_entry="value",
     parallelizes=False,
     needs_scaling=True,
-    disable_cache=False,
     is_available=IS_NLOPT_INSTALLED,
 )
 def nlopt_praxis(
@@ -150,7 +147,6 @@ def nlopt_praxis(
     primary_criterion_entry="value",
     parallelizes=False,
     needs_scaling=True,
-    disable_cache=False,
     is_available=IS_NLOPT_INSTALLED,
 )
 def nlopt_cobyla(
@@ -193,7 +189,6 @@ def nlopt_cobyla(
     primary_criterion_entry="value",
     parallelizes=False,
     needs_scaling=True,
-    disable_cache=False,
     is_available=IS_NLOPT_INSTALLED,
 )
 def nlopt_sbplx(
@@ -235,7 +230,6 @@ def nlopt_sbplx(
     primary_criterion_entry="value",
     parallelizes=False,
     needs_scaling=True,
-    disable_cache=False,
     is_available=IS_NLOPT_INSTALLED,
 )
 def nlopt_newuoa(
@@ -281,7 +275,6 @@ def nlopt_newuoa(
     primary_criterion_entry="value",
     parallelizes=False,
     needs_scaling=False,
-    disable_cache=False,
     is_available=IS_NLOPT_INSTALLED,
 )
 def nlopt_tnewton(
@@ -325,7 +318,6 @@ def nlopt_tnewton(
     primary_criterion_entry="value",
     parallelizes=False,
     needs_scaling=False,
-    disable_cache=False,
     is_available=IS_NLOPT_INSTALLED,
 )
 def nlopt_lbfgs(
@@ -369,7 +361,6 @@ def nlopt_lbfgs(
     primary_criterion_entry="value",
     parallelizes=False,
     needs_scaling=False,
-    disable_cache=False,
     is_available=IS_NLOPT_INSTALLED,
 )
 def nlopt_ccsaq(
@@ -413,7 +404,6 @@ def nlopt_ccsaq(
     primary_criterion_entry="value",
     parallelizes=False,
     needs_scaling=False,
-    disable_cache=False,
     is_available=IS_NLOPT_INSTALLED,
 )
 def nlopt_mma(
@@ -457,7 +447,6 @@ def nlopt_mma(
     primary_criterion_entry="value",
     parallelizes=False,
     needs_scaling=False,
-    disable_cache=False,
     is_available=IS_NLOPT_INSTALLED,
 )
 def nlopt_var(
@@ -506,7 +495,6 @@ def nlopt_var(
     primary_criterion_entry="value",
     parallelizes=False,
     needs_scaling=False,
-    disable_cache=False,
     is_available=IS_NLOPT_INSTALLED,
 )
 def nlopt_slsqp(
@@ -548,7 +536,6 @@ def nlopt_slsqp(
     primary_criterion_entry="value",
     parallelizes=False,
     needs_scaling=True,
-    disable_cache=False,
     is_available=IS_NLOPT_INSTALLED,
 )
 def nlopt_direct(
@@ -606,7 +593,6 @@ def nlopt_direct(
     primary_criterion_entry="value",
     parallelizes=False,
     needs_scaling=True,
-    disable_cache=False,
     is_available=IS_NLOPT_INSTALLED,
 )
 def nlopt_esch(
@@ -649,7 +635,6 @@ def nlopt_esch(
     primary_criterion_entry="value",
     parallelizes=False,
     needs_scaling=True,
-    disable_cache=False,
     is_available=IS_NLOPT_INSTALLED,
 )
 def nlopt_isres(
@@ -692,7 +677,6 @@ def nlopt_isres(
     primary_criterion_entry="value",
     parallelizes=False,
     needs_scaling=True,
-    disable_cache=False,
     is_available=IS_NLOPT_INSTALLED,
 )
 def nlopt_crs2_lm(

--- a/src/estimagic/optimization/optimize.py
+++ b/src/estimagic/optimization/optimize.py
@@ -24,7 +24,6 @@ from estimagic.optimization.tiktak import WEIGHT_FUNCTIONS
 from estimagic.parameters.conversion import get_converter
 from estimagic.parameters.parameter_groups import get_params_groups
 from estimagic.process_user_function import process_func_of_params
-from estimagic.utilities import hash_array
 
 
 def maximize(
@@ -48,7 +47,6 @@ def maximize(
     log_options=None,
     error_handling="raise",
     error_penalty=None,
-    cache_size=100,
     scaling=False,
     scaling_options=None,
     multistart=False,
@@ -132,8 +130,6 @@ def maximize(
             actually a bad function value. The default constant is f0 + abs(f0) + 100
             for minimizations and f0 - abs(f0) - 100 for maximizations, where
             f0 is the criterion value at start parameters. The default slope is 0.1.
-        cache_size (int): Number of criterion and derivative evaluations that are cached
-            in memory in case they are needed.
         scaling (bool): If True, the parameter vector is rescaled internally for
             better performance with scale sensitive optimizers.
         scaling_options (dict or None): Options to configure the internal scaling ot
@@ -212,7 +208,6 @@ def maximize(
         log_options=log_options,
         error_handling=error_handling,
         error_penalty=error_penalty,
-        cache_size=cache_size,
         scaling=scaling,
         scaling_options=scaling_options,
         multistart=multistart,
@@ -241,7 +236,6 @@ def minimize(
     log_options=None,
     error_handling="raise",
     error_penalty=None,
-    cache_size=100,
     scaling=False,
     scaling_options=None,
     multistart=False,
@@ -325,8 +319,6 @@ def minimize(
             actually a bad function value. The default constant is f0 + abs(f0) + 100
             for minimizations and f0 - abs(f0) - 100 for maximizations, where
             f0 is the criterion value at start parameters. The default slope is 0.1.
-        cache_size (int): Number of criterion and derivative evaluations that are cached
-            in memory in case they are needed.
         scaling (bool): If True, the parameter vector is rescaled internally for
             better performance with scale sensitive optimizers.
         scaling_options (dict or None): Options to configure the internal scaling ot
@@ -405,7 +397,6 @@ def minimize(
         log_options=log_options,
         error_handling=error_handling,
         error_penalty=error_penalty,
-        cache_size=cache_size,
         scaling=scaling,
         scaling_options=scaling_options,
         multistart=multistart,
@@ -435,7 +426,6 @@ def _optimize(
     log_options,
     error_handling,
     error_penalty,
-    cache_size,
     scaling,
     scaling_options,
     multistart,
@@ -482,7 +472,6 @@ def _optimize(
         log_options=log_options,
         error_handling=error_handling,
         error_penalty=error_penalty,
-        cache_size=cache_size,
         scaling=scaling,
         scaling_options=scaling_options,
         multistart=multistart,
@@ -646,10 +635,7 @@ def _optimize(
         direction=direction,
     )
 
-    # create cache
     x = internal_params.values
-    x_hash = hash_array(x)
-    cache = {x_hash: {"criterion": converter.func_to_internal(first_crit_eval)}}
     # ==================================================================================
     # get the internal algorithm
     # ==================================================================================
@@ -675,8 +661,6 @@ def _optimize(
         "numdiff_options": numdiff_options,
         "logging": logging,
         "db_kwargs": db_kwargs,
-        "cache": cache,
-        "cache_size": cache_size,
         "algo_info": algo_info,
         "error_handling": error_handling,
         "error_penalty_func": error_penalty_func,

--- a/src/estimagic/optimization/optimize.py
+++ b/src/estimagic/optimization/optimize.py
@@ -30,12 +30,6 @@ from estimagic.process_user_function import process_func_of_params
 from estimagic.utilities import hash_array
 
 
-BASE_DOCSTRING = """
-
-
-"""
-
-
 def maximize(
     criterion,
     params,

--- a/src/estimagic/optimization/optimize.py
+++ b/src/estimagic/optimization/optimize.py
@@ -480,7 +480,9 @@ def _optimize(
     # ==================================================================================
     # Get the algorithm info
     # ==================================================================================
-    raw_algo, algo_info, algo_kwargs = process_user_algorithm(algorithm)
+    raw_algo, algo_info = process_user_algorithm(algorithm)
+
+    algo_kwargs = set(algo_info.arguments)
 
     if algo_info.primary_criterion_entry == "root_contributions":
         if direction == "maximize":

--- a/src/estimagic/optimization/pounders.py
+++ b/src/estimagic/optimization/pounders.py
@@ -38,7 +38,6 @@ from estimagic.optimization.pounders_auxiliary import update_trustregion_radius
     name="pounders",
     primary_criterion_entry="root_contributions",
     needs_scaling=True,
-    parallelizes=True,
     is_available=True,
 )
 def pounders(

--- a/src/estimagic/optimization/pounders.py
+++ b/src/estimagic/optimization/pounders.py
@@ -39,7 +39,6 @@ from estimagic.optimization.pounders_auxiliary import update_trustregion_radius
     primary_criterion_entry="root_contributions",
     needs_scaling=True,
     parallelizes=True,
-    disable_cache=False,
     is_available=True,
 )
 def pounders(

--- a/src/estimagic/optimization/pygmo_optimizers.py
+++ b/src/estimagic/optimization/pygmo_optimizers.py
@@ -22,7 +22,7 @@ except ImportError:
 @mark_minimizer(
     name="pygmo_gaco",
     primary_criterion_entry="value",
-    parallelizes=True,
+    is_global=True,
     needs_scaling=True,
     is_available=IS_PYGMO_INSTALLED,
 )
@@ -104,7 +104,7 @@ def pygmo_gaco(
 @mark_minimizer(
     name="pygmo_bee_colony",
     primary_criterion_entry="value",
-    parallelizes=True,
+    is_global=True,
     needs_scaling=True,
     is_available=IS_PYGMO_INSTALLED,
 )
@@ -156,7 +156,7 @@ def pygmo_bee_colony(
 @mark_minimizer(
     name="pygmo_de",
     primary_criterion_entry="value",
-    parallelizes=True,
+    is_global=True,
     needs_scaling=True,
     is_available=IS_PYGMO_INSTALLED,
 )
@@ -235,7 +235,7 @@ def pygmo_de(
 @mark_minimizer(
     name="pygmo_sea",
     primary_criterion_entry="value",
-    parallelizes=True,
+    is_global=True,
     needs_scaling=True,
     is_available=IS_PYGMO_INSTALLED,
 )
@@ -285,7 +285,7 @@ def pygmo_sea(
 @mark_minimizer(
     name="pygmo_sga",
     primary_criterion_entry="value",
-    parallelizes=True,
+    is_global=True,
     needs_scaling=True,
     is_available=IS_PYGMO_INSTALLED,
 )
@@ -405,7 +405,7 @@ def pygmo_sga(
 @mark_minimizer(
     name="pygmo_sade",
     primary_criterion_entry="value",
-    parallelizes=True,
+    is_global=True,
     needs_scaling=True,
     is_available=IS_PYGMO_INSTALLED,
 )
@@ -492,7 +492,7 @@ def pygmo_sade(
 @mark_minimizer(
     name="pygmo_cmaes",
     primary_criterion_entry="value",
-    parallelizes=True,
+    is_global=True,
     needs_scaling=True,
     is_available=IS_PYGMO_INSTALLED,
 )
@@ -564,7 +564,7 @@ def pygmo_cmaes(
 @mark_minimizer(
     name="pygmo_simulated_annealing",
     primary_criterion_entry="value",
-    parallelizes=True,
+    is_global=True,
     needs_scaling=True,
     is_available=IS_PYGMO_INSTALLED,
 )
@@ -629,7 +629,7 @@ def pygmo_simulated_annealing(
 @mark_minimizer(
     name="pygmo_pso",
     primary_criterion_entry="value",
-    parallelizes=True,
+    is_global=True,
     needs_scaling=True,
     is_available=IS_PYGMO_INSTALLED,
 )
@@ -724,7 +724,7 @@ def pygmo_pso(
 @mark_minimizer(
     name="pygmo_pso_gen",
     primary_criterion_entry="value",
-    parallelizes=True,
+    is_global=True,
     needs_scaling=True,
     is_available=IS_PYGMO_INSTALLED,
 )
@@ -818,7 +818,7 @@ def pygmo_pso_gen(
 @mark_minimizer(
     name="pygmo_mbh",
     primary_criterion_entry="value",
-    parallelizes=True,
+    is_global=True,
     needs_scaling=True,
     is_available=IS_PYGMO_INSTALLED,
 )
@@ -878,7 +878,7 @@ def pygmo_mbh(
 @mark_minimizer(
     name="pygmo_xnes",
     primary_criterion_entry="value",
-    parallelizes=True,
+    is_global=True,
     needs_scaling=True,
     is_available=IS_PYGMO_INSTALLED,
 )
@@ -948,7 +948,7 @@ def pygmo_xnes(
 @mark_minimizer(
     name="pygmo_gwo",
     primary_criterion_entry="value",
-    parallelizes=True,
+    is_global=True,
     needs_scaling=True,
     is_available=IS_PYGMO_INSTALLED,
 )
@@ -998,7 +998,7 @@ def pygmo_gwo(
 @mark_minimizer(
     name="pygmo_compass_search",
     primary_criterion_entry="value",
-    parallelizes=True,
+    is_global=True,
     needs_scaling=True,
     is_available=IS_PYGMO_INSTALLED,
 )
@@ -1063,7 +1063,7 @@ def pygmo_compass_search(
 @mark_minimizer(
     name="pygmo_ihs",
     primary_criterion_entry="value",
-    parallelizes=True,
+    is_global=True,
     needs_scaling=True,
     is_available=IS_PYGMO_INSTALLED,
 )
@@ -1131,7 +1131,7 @@ def pygmo_ihs(
 @mark_minimizer(
     name="pygmo_de1220",
     primary_criterion_entry="value",
-    parallelizes=True,
+    is_global=True,
     needs_scaling=True,
     is_available=IS_PYGMO_INSTALLED,
 )

--- a/src/estimagic/optimization/pygmo_optimizers.py
+++ b/src/estimagic/optimization/pygmo_optimizers.py
@@ -24,7 +24,6 @@ except ImportError:
     primary_criterion_entry="value",
     parallelizes=True,
     needs_scaling=True,
-    disable_cache=False,
     is_available=IS_PYGMO_INSTALLED,
 )
 def pygmo_gaco(
@@ -107,7 +106,6 @@ def pygmo_gaco(
     primary_criterion_entry="value",
     parallelizes=True,
     needs_scaling=True,
-    disable_cache=False,
     is_available=IS_PYGMO_INSTALLED,
 )
 def pygmo_bee_colony(
@@ -160,7 +158,6 @@ def pygmo_bee_colony(
     primary_criterion_entry="value",
     parallelizes=True,
     needs_scaling=True,
-    disable_cache=False,
     is_available=IS_PYGMO_INSTALLED,
 )
 def pygmo_de(
@@ -240,7 +237,6 @@ def pygmo_de(
     primary_criterion_entry="value",
     parallelizes=True,
     needs_scaling=True,
-    disable_cache=False,
     is_available=IS_PYGMO_INSTALLED,
 )
 def pygmo_sea(
@@ -291,7 +287,6 @@ def pygmo_sea(
     primary_criterion_entry="value",
     parallelizes=True,
     needs_scaling=True,
-    disable_cache=False,
     is_available=IS_PYGMO_INSTALLED,
 )
 def pygmo_sga(
@@ -412,7 +407,6 @@ def pygmo_sga(
     primary_criterion_entry="value",
     parallelizes=True,
     needs_scaling=True,
-    disable_cache=False,
     is_available=IS_PYGMO_INSTALLED,
 )
 def pygmo_sade(
@@ -500,7 +494,6 @@ def pygmo_sade(
     primary_criterion_entry="value",
     parallelizes=True,
     needs_scaling=True,
-    disable_cache=False,
     is_available=IS_PYGMO_INSTALLED,
 )
 def pygmo_cmaes(
@@ -573,7 +566,6 @@ def pygmo_cmaes(
     primary_criterion_entry="value",
     parallelizes=True,
     needs_scaling=True,
-    disable_cache=False,
     is_available=IS_PYGMO_INSTALLED,
 )
 def pygmo_simulated_annealing(
@@ -639,7 +631,6 @@ def pygmo_simulated_annealing(
     primary_criterion_entry="value",
     parallelizes=True,
     needs_scaling=True,
-    disable_cache=False,
     is_available=IS_PYGMO_INSTALLED,
 )
 def pygmo_pso(
@@ -735,7 +726,6 @@ def pygmo_pso(
     primary_criterion_entry="value",
     parallelizes=True,
     needs_scaling=True,
-    disable_cache=False,
     is_available=IS_PYGMO_INSTALLED,
 )
 def pygmo_pso_gen(
@@ -830,7 +820,6 @@ def pygmo_pso_gen(
     primary_criterion_entry="value",
     parallelizes=True,
     needs_scaling=True,
-    disable_cache=False,
     is_available=IS_PYGMO_INSTALLED,
 )
 def pygmo_mbh(
@@ -891,7 +880,6 @@ def pygmo_mbh(
     primary_criterion_entry="value",
     parallelizes=True,
     needs_scaling=True,
-    disable_cache=False,
     is_available=IS_PYGMO_INSTALLED,
 )
 def pygmo_xnes(
@@ -962,7 +950,6 @@ def pygmo_xnes(
     primary_criterion_entry="value",
     parallelizes=True,
     needs_scaling=True,
-    disable_cache=False,
     is_available=IS_PYGMO_INSTALLED,
 )
 def pygmo_gwo(
@@ -1013,7 +1000,6 @@ def pygmo_gwo(
     primary_criterion_entry="value",
     parallelizes=True,
     needs_scaling=True,
-    disable_cache=False,
     is_available=IS_PYGMO_INSTALLED,
 )
 def pygmo_compass_search(
@@ -1079,7 +1065,6 @@ def pygmo_compass_search(
     primary_criterion_entry="value",
     parallelizes=True,
     needs_scaling=True,
-    disable_cache=False,
     is_available=IS_PYGMO_INSTALLED,
 )
 def pygmo_ihs(
@@ -1148,7 +1133,6 @@ def pygmo_ihs(
     primary_criterion_entry="value",
     parallelizes=True,
     needs_scaling=True,
-    disable_cache=False,
     is_available=IS_PYGMO_INSTALLED,
 )
 def pygmo_de1220(

--- a/src/estimagic/optimization/tao_optimizers.py
+++ b/src/estimagic/optimization/tao_optimizers.py
@@ -22,7 +22,6 @@ except ImportError:
     primary_criterion_entry="root_contributions",
     is_available=IS_PETSC4PY_INSTALLED,
     needs_scaling=True,
-    disable_cache=True,
 )
 def tao_pounders(
     criterion,

--- a/src/estimagic/optimization/tao_optimizers.py
+++ b/src/estimagic/optimization/tao_optimizers.py
@@ -48,11 +48,11 @@ def tao_pounders(
             "Windows. Windows users can use estimagics 'pounders' algorithm instead."
         )
 
-    x = _initialise_petsc_array(x)
-    # We need to know the number of contributions of the criterion value to allocate the
-    # array.
     first_eval = criterion(x)
     n_errors = len(first_eval)
+    _x = _initialise_petsc_array(x)
+    # We need to know the number of contributions of the criterion value to allocate the
+    # array.
     residuals_out = _initialise_petsc_array(n_errors)
 
     # Create the solver object.
@@ -81,7 +81,7 @@ def tao_pounders(
     tao.setResidual(func_tao, residuals_out)
 
     if trustregion_initial_radius is None:
-        trustregion_initial_radius = calculate_trustregion_initial_radius(x)
+        trustregion_initial_radius = calculate_trustregion_initial_radius(_x)
     elif trustregion_initial_radius <= 0:
         raise ValueError("The initial trust region radius must be > 0.")
     tao.setInitialTrustRegionRadius(trustregion_initial_radius)
@@ -92,7 +92,7 @@ def tao_pounders(
     tao.setVariableBounds(lower_bounds, upper_bounds)
 
     # Put the starting values into the container and pass them to the optimizer.
-    tao.setInitial(x)
+    tao.setInitial(_x)
 
     # Obtain tolerances for the convergence criteria. Since we can not create
     # scaled_gradient_tolerance manually we manually set absolute_gradient_tolerance and
@@ -153,7 +153,7 @@ def tao_pounders(
     results = _process_pounders_results(residuals_out, tao)
 
     # Destroy petsc objects for memory reasons.
-    for obj in [tao, x, residuals_out, lower_bounds, upper_bounds]:
+    for obj in [tao, _x, residuals_out, lower_bounds, upper_bounds]:
         obj.destroy()
 
     return results

--- a/src/estimagic/optimization/tao_optimizers.py
+++ b/src/estimagic/optimization/tao_optimizers.py
@@ -22,6 +22,7 @@ except ImportError:
     primary_criterion_entry="root_contributions",
     is_available=IS_PETSC4PY_INSTALLED,
     needs_scaling=True,
+    disable_cache=True,
 )
 def tao_pounders(
     criterion,
@@ -50,9 +51,8 @@ def tao_pounders(
     x = _initialise_petsc_array(x)
     # We need to know the number of contributions of the criterion value to allocate the
     # array.
-    n_errors = len(
-        criterion.keywords["first_criterion_evaluation"]["output"]["root_contributions"]
-    )
+    first_eval = criterion(x)
+    n_errors = len(first_eval)
     residuals_out = _initialise_petsc_array(n_errors)
 
     # Create the solver object.

--- a/src/estimagic/optimization/tiktak.py
+++ b/src/estimagic/optimization/tiktak.py
@@ -334,6 +334,7 @@ def run_explorations(
         needs_scaling=False,
         name="tiktak_explorer",
         is_available=True,
+        arguments=[],
     )
 
     _func = partial(

--- a/src/estimagic/optimization/tiktak.py
+++ b/src/estimagic/optimization/tiktak.py
@@ -333,7 +333,6 @@ def run_explorations(
         parallelizes=True,
         needs_scaling=False,
         name="tiktak_explorer",
-        disable_cache=True,
         is_available=True,
     )
 

--- a/src/estimagic/optimization/tiktak.py
+++ b/src/estimagic/optimization/tiktak.py
@@ -32,7 +32,6 @@ def run_multistart_optimization(
     logging,
     db_kwargs,
     error_handling,
-    error_penalty,
 ):
     steps = determine_steps(options["n_samples"], options["n_optimizations"])
 
@@ -131,7 +130,7 @@ def run_multistart_optimization(
     }
 
     problem_functions = {
-        name: partial(func, error_handling=error_handling, error_penalty=error_penalty)
+        name: partial(func, error_handling=error_handling)
         for name, func in problem_functions.items()
     }
 
@@ -307,8 +306,7 @@ def run_explorations(
     Args:
         func (callable): An already partialled version of
             ``internal_criterion_and_derivative_template`` where the following arguments
-            are still free: ``x``, ``task``, ``algo_info``, ``error_handling``,
-            ``error_penalty``, ``fixed_log_data``.
+            are still free: ``x``, ``task``, ``error_handling``, ``fixed_log_data``.
         primary_key: The primary criterion entry of the local optimizer. Needed to
             interpret the output of the internal criterion function.
         sample (numpy.ndarray): 2d numpy array where each row is a sampled internal
@@ -344,7 +342,6 @@ def run_explorations(
         task="criterion",
         algo_info=algo_info,
         error_handling=error_handling,
-        error_penalty={"constant": np.nan, "slope": np.nan},
     )
 
     arguments = []

--- a/src/estimagic/parameters/conversion.py
+++ b/src/estimagic/parameters/conversion.py
@@ -234,12 +234,16 @@ def _get_fast_path_converter(params, lower_bounds, upper_bounds, primary_key):
 
     if lower_bounds is None:
         lower_bounds = np.full(len(params), -np.inf)
+    else:
+        lower_bounds = lower_bounds.astype(float)
 
     if upper_bounds is None:
         upper_bounds = np.full(len(params), np.inf)
+    else:
+        upper_bounds = upper_bounds.astype(float)
 
     flat_params = FlatParams(
-        values=params,
+        values=params.astype(float),
         lower_bounds=lower_bounds,
         upper_bounds=upper_bounds,
         free_mask=np.full(len(params), True),
@@ -288,6 +292,10 @@ def _is_fast_func_eval(f, key):
 
 
 def _is_fast_deriv_eval(d, key):
+    # this is the case if no or closed form derivatives are used
+    if d is None:
+        return True
+
     if key == "value":
         if not (_is_1d_arr(d) or (_is_dict_with(d, key) and _is_1d_arr(d[key]))):
             return False

--- a/tests/optimization/test_error_penalty.py
+++ b/tests/optimization/test_error_penalty.py
@@ -1,0 +1,101 @@
+import functools
+
+import numpy as np
+import pytest
+from estimagic.differentiation.derivatives import first_derivative
+from estimagic.optimization.error_penalty import _penalty_contributions
+from estimagic.optimization.error_penalty import _penalty_contributions_derivative
+from estimagic.optimization.error_penalty import (
+    _penalty_root_contributions,
+)
+from estimagic.optimization.error_penalty import _penalty_root_contributions_derivative
+from estimagic.optimization.error_penalty import _penalty_value
+from estimagic.optimization.error_penalty import _penalty_value_derivative
+from estimagic.optimization.error_penalty import get_error_penalty_function
+from numpy.testing import assert_array_almost_equal as aaae
+
+
+@pytest.mark.parametrize("seed", range(10))
+def test_penalty_aggregations(seed):
+    np.random.seed(seed)
+    x = np.random.uniform(size=5)
+    x0 = np.random.uniform(size=5)
+    slope = 0.3
+    constant = 3
+    dim_out = 10
+
+    scalar = _penalty_value(x, constant, slope, x0)
+    contribs = _penalty_contributions(x, constant, slope, x0, dim_out)
+    root_contribs = _penalty_root_contributions(x, constant, slope, x0, dim_out)
+
+    assert np.isclose(scalar, contribs.sum())
+    assert np.isclose(scalar, (root_contribs**2).sum())
+
+
+pairs = [
+    (_penalty_value, _penalty_value_derivative),
+    (_penalty_contributions, _penalty_contributions_derivative),
+    (_penalty_root_contributions, _penalty_root_contributions_derivative),
+]
+
+
+@pytest.mark.parametrize("func, deriv", pairs)
+def test_penalty_derivatives(func, deriv):
+    np.random.seed(1234)
+    x = np.random.uniform(size=5)
+    x0 = np.random.uniform(size=5)
+    slope = 0.3
+    constant = 3
+    dim_out = 8
+
+    calculated = deriv(x, constant, slope, x0, dim_out)
+
+    partialed = functools.partial(
+        func, constant=constant, slope=slope, x0=x0, dim_out=dim_out
+    )
+    expected = first_derivative(partialed, x)
+
+    aaae(calculated, expected["derivative"])
+
+
+@pytest.mark.parametrize("seed", range(10))
+def test_penalty_aggregations_via_get_error_penalty(seed):
+    np.random.seed(seed)
+    x = np.random.uniform(size=5)
+    x0 = np.random.uniform(size=5)
+    slope = 0.3
+    constant = 3
+
+    scalar_func = get_error_penalty_function(
+        error_handling="continue",
+        start_x=x0,
+        start_criterion=3,
+        error_penalty={"slope": slope, "constant": constant},
+        primary_key="value",
+        direction="minimize",
+    )
+
+    contribs_func = get_error_penalty_function(
+        error_handling="continue",
+        start_x=x0,
+        start_criterion=np.ones(10),
+        error_penalty={"slope": slope, "constant": constant},
+        primary_key="contributions",
+        direction="minimize",
+    )
+
+    root_contribs_func = get_error_penalty_function(
+        error_handling="continue",
+        start_x=x0,
+        start_criterion=np.ones(10),
+        error_penalty={"slope": slope, "constant": constant},
+        primary_key="root_contributions",
+        direction="minimize",
+    )
+
+    scalar = scalar_func(x, task="criterion")
+    contribs = contribs_func(x, task="criterion")
+    root_contribs = root_contribs_func(x, task="criterion")
+
+    assert np.isclose(scalar, contribs.sum())
+    assert np.isclose(scalar, (root_contribs**2).sum())

--- a/tests/optimization/test_internal_criterion_and_derivative_template.py
+++ b/tests/optimization/test_internal_criterion_and_derivative_template.py
@@ -39,7 +39,6 @@ def base_inputs():
             primary_criterion_entry="value",
             parallelizes=False,
             needs_scaling=False,
-            disable_cache=False,
             is_available=True,
         ),
         "error_handling": "raise",

--- a/tests/optimization/test_internal_criterion_and_derivative_template.py
+++ b/tests/optimization/test_internal_criterion_and_derivative_template.py
@@ -37,9 +37,10 @@ def base_inputs():
         "algo_info": AlgoInfo(
             name="my_algorithm",
             primary_criterion_entry="value",
-            parallelizes=False,
             needs_scaling=False,
             is_available=True,
+            parallelizes=False,
+            arguments=[],
         ),
         "error_handling": "raise",
         "numdiff_options": {},

--- a/tests/optimization/test_many_algorithms.py
+++ b/tests/optimization/test_many_algorithms.py
@@ -46,6 +46,8 @@ def test_algorithm_on_sum_of_squares(algorithm):
         criterion=sos,
         params=np.arange(3),
         algorithm=algorithm,
+        collect_history=False,
+        skip_checks=True,
     )
 
     assert res["success"] in [True, None]
@@ -65,6 +67,8 @@ def test_algorithm_on_sum_of_squares_with_binding_bounds(algorithm):
         lower_bounds=np.array([1, -np.inf, -np.inf]),
         upper_bounds=np.array([np.inf, np.inf, -1]),
         algorithm=algorithm,
+        collect_history=False,
+        skip_checks=True,
     )
 
     assert res["success"] in [True, None]
@@ -90,6 +94,8 @@ def test_global_algorithms_on_sum_of_squares(algorithm):
         lower_bounds=np.array([0.2, -0.5]),
         upper_bounds=np.array([1, 0.5]),
         algorithm=algorithm,
+        collect_history=False,
+        skip_checks=True,
     )
     assert res["success"] in [True, None]
     aaae(res["solution_params"], np.array([0.2, 0]), decimal=1)

--- a/tests/optimization/test_tiktak.py
+++ b/tests/optimization/test_tiktak.py
@@ -62,7 +62,6 @@ def test_run_explorations():
             "task",
             "algo_info",
             "error_handling",
-            "error_penalty",
             "fixed_log_data",
         }
         if x.sum() == 5:

--- a/tests/parameters/test_conversion.py
+++ b/tests/parameters/test_conversion.py
@@ -187,6 +187,9 @@ FAST_DERIV_CASES = [
     ("contributions", {"contributions": helper}),
     ("root_contributions", helper),
     ("root_contributions", {"root_contributions": helper}),
+    ("value", None),
+    ("contributions", None),
+    ("root_contributions", None),
 ]
 
 
@@ -213,9 +216,6 @@ SLOW_DERIV_CASES = [
     ("contributions", {"contributions": np.arange(8).reshape(2, 2, 2)}),
     ("root_contributions", np.arange(8).reshape(2, 2, 2)),
     ("root_contributions", {"root_contributions": np.arange(8).reshape(2, 2, 2)}),
-    ("value", None),
-    ("contributions", None),
-    ("root_contributions", None),
 ]
 
 

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -77,7 +77,6 @@ INVALID_TYPES = [
     {"name": None},
     {"name": [1, 2, 3]},
     {"parallelizes": 15},
-    {"disable_cache": 20},
     {"needs_scaling": 25},
     {"is_available": 30},
 ]

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -76,7 +76,6 @@ def test_mark_minimizer_direct_call():
 INVALID_TYPES = [
     {"name": None},
     {"name": [1, 2, 3]},
-    {"parallelizes": 15},
     {"needs_scaling": 25},
     {"is_available": 30},
 ]


### PR DESCRIPTION
## Goal

collect the optimizer histories (for criterion values and parameter vectors that have been tried) during optimization and add them to the result. 

For now, this will only worked for optimizers that do not parallelize. It will however work with parallel numerical derivatives or parallel multistart optimizations.

This is a preparation for #323 and #314 

## To-Do

- [x] Get rid of `first_eval` and `cache` in `internal_criterion_and_derivative`
- [x] Improve internal algorithm interface such that we can find out if an optimizer actually parallelizes
- [x] Add history collection for non parallelizing optimizers
    - [x] standard optimization
    - [x] multistart
- [x] Make history collection optional 