### PR TITLE
Improve Benchmarking

### DIFF
--- a/src/estimagic/benchmarking/get_benchmark_problems.py
+++ b/src/estimagic/benchmarking/get_benchmark_problems.py
@@ -165,6 +165,7 @@ def _internal_criterion_template(
         }
     else:
         out = noisy_critval
+
     return out
 
 

--- a/src/estimagic/benchmarking/get_benchmark_problems.py
+++ b/src/estimagic/benchmarking/get_benchmark_problems.py
@@ -2,7 +2,6 @@ import warnings
 from functools import partial
 
 import numpy as np
-import pandas as pd
 from estimagic.benchmarking.cartis_roberts import CARTIS_ROBERTS_PROBLEMS
 from estimagic.benchmarking.more_wild import MORE_WILD_PROBLEMS
 from estimagic.benchmarking.noise_distributions import NOISE_DISTRIBUTIONS
@@ -54,7 +53,7 @@ def get_benchmark_problems(
             {"name": {"inputs": {...}, "solution": {...}, "info": {...}}}
             where "inputs" are keyword arguments for ``minimize`` such as the criterion
             function and start parameters. "solution" contains the entries "params" and
-            "value" and "info" might  contain information about the test problem.
+            "value" and "info" might contain information about the test problem.
 
     """
     raw_problems = _get_raw_problems(name)
@@ -127,9 +126,7 @@ def _create_problem_inputs(specification, additive_options, multiplicative_optio
     )
     _x = specification["start_x"]
 
-    _params = pd.DataFrame(_x.reshape(-1, 1), columns=["value"])
-
-    inputs = {"criterion": _criterion, "params": _params}
+    inputs = {"criterion": _criterion, "params": _x}
     return inputs
 
 
@@ -138,7 +135,7 @@ def _create_problem_solution(specification):
     if _solution_x is None:
         _solution_x = specification["start_x"] * np.nan
 
-    _params = pd.DataFrame(_solution_x.reshape(-1, 1), columns=["value"])
+    _params = _solution_x.reshape(-1, 1)
     _value = specification["solution_criterion"]
 
     solution = {
@@ -151,8 +148,7 @@ def _create_problem_solution(specification):
 def _internal_criterion_template(
     params, criterion, additive_options, multiplicative_options
 ):
-    x = params["value"].to_numpy()
-    critval = criterion(x)
+    critval = criterion(params)
 
     noise = _get_combined_noise(
         critval,

--- a/src/estimagic/benchmarking/get_benchmark_problems.py
+++ b/src/estimagic/benchmarking/get_benchmark_problems.py
@@ -135,7 +135,7 @@ def _create_problem_solution(specification):
     if _solution_x is None:
         _solution_x = specification["start_x"] * np.nan
 
-    _params = _solution_x.reshape(-1, 1)
+    _params = _solution_x
     _value = specification["solution_criterion"]
 
     solution = {

--- a/src/estimagic/benchmarking/process_benchmark_results.py
+++ b/src/estimagic/benchmarking/process_benchmark_results.py
@@ -1,5 +1,7 @@
 import numpy as np
 import pandas as pd
+from estimagic.parameters.tree_registry import get_registry
+from pybaum import tree_just_flatten
 
 
 def create_convergence_histories(
@@ -40,15 +42,16 @@ def create_convergence_histories(
             - parameter_distance_normalized
             - monotone_parameter_distance
             - monotone_parameter_distance_normalized
-
     """
     # get solution values for each problem
+    registry = get_registry(extended=True)
+    x_opt = {
+        name: tree_just_flatten(prob["solution"]["params"], registry=registry)
+        for name, prob in problems.items()
+    }
     f_opt = pd.Series(
         {name: prob["solution"]["value"] for name, prob in problems.items()}
     )
-    x_opt = {
-        name: prob["solution"]["params"]["value"] for name, prob in problems.items()
-    }
 
     # build df from results
     time_sr = _get_history_as_stacked_sr_from_results(results, "time_history")
@@ -136,6 +139,7 @@ def _get_history_of_the_parameter_distance(results, x_opt):
     x_dist_history = {}
     for (prob, algo), res in results.items():
         param_history = res["params_history"]
+
         x_dist_history[(prob, algo)] = pd.Series(
             np.linalg.norm(param_history - x_opt[prob], axis=1)
         )

--- a/src/estimagic/benchmarking/run_benchmark.py
+++ b/src/estimagic/benchmarking/run_benchmark.py
@@ -155,7 +155,7 @@ def _get_kwargs_list_and_names_logging(
 def _get_results_history(names, raw_results, kwargs_list):
     results = {}
 
-    for name, result, kwargs in zip(names, raw_results, kwargs_list):
+    for name, result, inputs in zip(names, raw_results, kwargs_list):
 
         if isinstance(result, dict):
             params_history = pd.concat(
@@ -173,8 +173,10 @@ def _get_results_history(names, raw_results, kwargs_list):
             runtime = (stop - start).total_seconds()
             time_history = timestamps - start
         else:
-            criterion_history = pd.Series(np.inf)
-            params_history = kwargs["params"]
+            _criterion = inputs["criterion"]
+
+            params_history = inputs["params"]
+            criterion_history = pd.Series(_criterion(params_history)["value"])
 
             runtime = pd.Series([], dtype="datetime64[ns]")
             time_history = pd.Series([], dtype="datetime64[ns]")

--- a/src/estimagic/benchmarking/run_benchmark.py
+++ b/src/estimagic/benchmarking/run_benchmark.py
@@ -122,7 +122,7 @@ def _get_results(names, raw_results, kwargs_list):
             timestamps = pd.Series([hist["timestamp"] for hist in result["history"]])
             stop = timestamps.max()
             start = timestamps.min()
-            runtime = (stop - start).total_seconds()
+            runtime = stop - start
             time_history = timestamps - start
         else:
             _criterion = inputs["criterion"]
@@ -133,8 +133,8 @@ def _get_results(names, raw_results, kwargs_list):
             ).T
             criterion_history = pd.Series(_criterion(inputs["params"])["value"])
 
-            runtime = pd.Series([], dtype="datetime64[ns]")
-            time_history = pd.Series([], dtype="datetime64[ns]")
+            runtime = pd.Series([np.inf])
+            time_history = pd.Series([np.inf])
 
         results[name] = {
             "params_history": params_history,

--- a/src/estimagic/benchmarking/run_benchmark.py
+++ b/src/estimagic/benchmarking/run_benchmark.py
@@ -123,9 +123,9 @@ def _get_results(names, raw_results, kwargs_list):
                 [hist["scalar_criterion"] for hist in result["history"]]
             )
 
-            timestamps = pd.Series([hist["timestamp"] for hist in result["history"]])
-            start = timestamps.min()
-            time_history = timestamps - start
+            timestamps = np.array([hist["timestamp"] for hist in result["history"]])
+            start = timestamps[0]
+            time_history = pd.Series(timestamps - start)
         elif isinstance(result, str):
             _criterion = inputs["criterion"]
 

--- a/src/estimagic/benchmarking/run_benchmark.py
+++ b/src/estimagic/benchmarking/run_benchmark.py
@@ -47,7 +47,7 @@ def run_benchmark(
         dict: Nested Dictionary with information on the benchmark run. The outer keys
             are tuples where the first entry is the name of the problem and the second
             the name of the optimize options. The values are dicts with the entries:
-            "runtime", "params_history", "criterion_history", "solution".
+            "params_history", "criterion_history", "time_history" and "solution".
     """
     np.random.seed(seed)
 
@@ -124,9 +124,7 @@ def _get_results(names, raw_results, kwargs_list):
             )
 
             timestamps = pd.Series([hist["timestamp"] for hist in result["history"]])
-            stop = timestamps.max()
             start = timestamps.min()
-            runtime = stop - start
             time_history = timestamps - start
         elif isinstance(result, str):
             _criterion = inputs["criterion"]
@@ -136,7 +134,6 @@ def _get_results(names, raw_results, kwargs_list):
             ).T
             criterion_history = pd.Series(_criterion(inputs["params"])["value"])
 
-            runtime = pd.Series([np.inf])
             time_history = pd.Series([np.inf])
         else:
             raise ValueError(
@@ -148,7 +145,6 @@ def _get_results(names, raw_results, kwargs_list):
             "criterion_history": criterion_history,
             "time_history": time_history,
             "solution": result,
-            "runtime": runtime,
         }
 
     return results

--- a/src/estimagic/optimization/internal_criterion_template.py
+++ b/src/estimagic/optimization/internal_criterion_template.py
@@ -246,6 +246,7 @@ def internal_criterion_and_derivative_template(
     if history_container is not None:
         hist_entry = {
             "params": current_params,
+            "flat_params": external_x,
             "criterion": new_criterion,
             "scalar_criterion": scalar_critval,
             "timestamp": datetime.datetime.now(),

--- a/src/estimagic/optimization/internal_criterion_template.py
+++ b/src/estimagic/optimization/internal_criterion_template.py
@@ -67,7 +67,7 @@ def internal_criterion_and_derivative_template(
         numdiff_options (dict): Keyword arguments for the calculation of numerical
             derivatives. See :ref:`first_derivative` for details. Note that the default
             method is changed to "forward" for speed reasons.
-        logging (bool): Wether logging is used.
+        logging (bool): Whether logging is used.
         db_kwargs (dict): Dictionary with entries "database", "path" and "fast_logging".
         error_handling (str): Either "raise" or "continue". Note that "continue" does
             not absolutely guarantee that no error is raised but we try to handle as
@@ -248,8 +248,10 @@ def internal_criterion_and_derivative_template(
             "params": current_params,
             "criterion": new_criterion,
             "scalar_criterion": scalar_critval,
+            "timestamp": datetime.datetime.now(),
         }
         history_container.append(hist_entry)
+
     return res
 
 

--- a/src/estimagic/optimization/internal_criterion_template.py
+++ b/src/estimagic/optimization/internal_criterion_template.py
@@ -247,7 +247,6 @@ def internal_criterion_and_derivative_template(
     if history_container is not None:
         hist_entry = {
             "params": current_params,
-            "flat_params": external_x,
             "criterion": new_criterion,
             "scalar_criterion": scalar_critval,
             "timestamp": time.perf_counter(),

--- a/src/estimagic/optimization/internal_criterion_template.py
+++ b/src/estimagic/optimization/internal_criterion_template.py
@@ -1,4 +1,5 @@
 import datetime
+import time
 import warnings
 
 from estimagic.differentiation.derivatives import first_derivative
@@ -249,7 +250,7 @@ def internal_criterion_and_derivative_template(
             "flat_params": external_x,
             "criterion": new_criterion,
             "scalar_criterion": scalar_critval,
-            "timestamp": datetime.datetime.now(),
+            "timestamp": time.perf_counter(),
         }
         history_container.append(hist_entry)
 
@@ -313,7 +314,6 @@ def _log_new_evaluations(
     Note: There are some seemingly unnecessary type conversions because sqlalchemy
     can fail silently when called with numpy dtypes instead of the equivalent python
     types.
-
     """
     data = {
         "params": external_x,

--- a/src/estimagic/visualization/profile_plot.py
+++ b/src/estimagic/visualization/profile_plot.py
@@ -1,5 +1,3 @@
-import warnings
-
 import numpy as np
 import pandas as pd
 import plotly.express as px
@@ -88,20 +86,8 @@ def profile_plot(
 
     if normalize_runtime:
         solution_times = solution_times.divide(solution_times.min(axis=1), axis=0)
-        # set again to inf because no inf Timedeltas were allowed.
         solution_times[~converged_info] = np.inf
-    else:
-        if (
-            runtime_measure == "walltime"
-            and (solution_times == pd.Timedelta(weeks=1000)).any().any()
-        ):
-            warnings.warn(
-                "Some algorithms did not converge. Their walltime has been "
-                "set to a very high value instead of infinity because Timedeltas do not"
-                "support infinite values."
-            )
 
-    # create performance profiles
     alphas = _determine_alpha_grid(solution_times)
     for_each_alpha = pd.concat(
         {alpha: solution_times <= alpha for alpha in alphas},
@@ -109,12 +95,8 @@ def profile_plot(
     )
     performance_profiles = for_each_alpha.groupby("alpha").mean().stack().reset_index()
 
-    # Build plot
-
     fig = px.line(performance_profiles, x="alpha", y=0, color="algorithm")
-    # dropped some styling parameters
 
-    # Plot Styling
     xlabels = {
         ("n_evaluations", True): "Multiple of Minimal Number of Function Evaluations\n"
         "Needed to Solve the Problem",
@@ -136,7 +118,7 @@ def profile_plot(
         template=template,
     )
 
-    fig.add_hline(y=1)  # dropped styling
+    fig.add_hline(y=1)
     return fig
 
 
@@ -162,25 +144,13 @@ def _create_solution_times(df, runtime_measure, converged_info):
     solution_times = df.groupby(["problem", "algorithm"])[runtime_measure].max()
     solution_times = solution_times.unstack()
 
-    # inf not allowed for timedeltas so put something very large
-    if runtime_measure == "walltime":
-        inf_value = pd.Timedelta(weeks=1000)
-    elif runtime_measure == "n_evaluations":
-        inf_value = np.inf
-    else:
-        raise ValueError(
-            "Only 'walltime' or 'n_evaluations' are allowed as "
-            f"runtime_measure. You specified {runtime_measure}."
-        )
-
-    solution_times[~converged_info] = inf_value
+    solution_times[~converged_info] = np.inf
     return solution_times
 
 
 def _determine_alpha_grid(solution_times):
     switch_points = _find_switch_points(solution_times=solution_times)
 
-    # add point to the right
     point_to_right = switch_points[-1] * 1.05
     extended_switch_points = np.append(switch_points, point_to_right)
     mid_points = (extended_switch_points[:-1] + extended_switch_points[1:]) / 2

--- a/src/estimagic/visualization/profile_plot.py
+++ b/src/estimagic/visualization/profile_plot.py
@@ -67,9 +67,7 @@ def profile_plot(
 
     Returns:
         plotly.Figure
-
     """
-
     if stopping_criterion is None:
         raise ValueError(
             "You must specify a stopping criterion for the performance plot. "

--- a/src/estimagic/visualization/profile_plot.py
+++ b/src/estimagic/visualization/profile_plot.py
@@ -70,6 +70,12 @@ def profile_plot(
         raise ValueError(
             "You must specify a stopping criterion for the performance plot. "
         )
+    if runtime_measure not in ["walltime", "n_evaluations"]:
+        raise ValueError(
+            "Only 'walltime' or 'n_evaluations' are allowed as "
+            f"runtime_measure. You specified {runtime_measure}."
+        )
+
     df, converged_info = create_convergence_histories(
         problems=problems,
         results=results,

--- a/tests/benchmarking/test_run_benchmark.py
+++ b/tests/benchmarking/test_run_benchmark.py
@@ -1,3 +1,4 @@
+import pytest
 from estimagic import get_benchmark_problems
 from estimagic.benchmarking.run_benchmark import run_benchmark
 
@@ -66,3 +67,24 @@ def test_run_benchmark_list_options(tmpdir):
 
     assert set(res_logging) == expected_keys
     assert set(res_history) == expected_keys
+
+
+@pytest.mark.parametrize("failing_name", [("jennrich_sampson"), ("osborne_one")])
+def test_run_benchmark_failing(failing_name, tmpdir):
+    all_problems = get_benchmark_problems("more_wild")
+    failing = {failing_name: all_problems[failing_name]}
+
+    optimize_options = ["scipy_lbfgsb"]
+
+    logging_directory = tmpdir / "benchmark_logs"
+    with pytest.warns():
+        res_history = run_benchmark(problems=failing, optimize_options=optimize_options)
+        res_logging = run_benchmark(
+            problems=failing,
+            optimize_options=optimize_options,
+            logging_directory=logging_directory,
+        )
+
+    key = (failing_name, "scipy_lbfgsb")
+    assert isinstance(res_history[key]["solution"], str)
+    assert isinstance(res_logging[key]["solution"], str)

--- a/tests/benchmarking/test_run_benchmark.py
+++ b/tests/benchmarking/test_run_benchmark.py
@@ -16,16 +16,16 @@ def test_run_benchmark_dict_options(tmpdir):
         },
     }
 
+    res_history = run_benchmark(
+        problems=first_two,
+        optimize_options=optimize_options,
+    )
+
     logging_directory = tmpdir / "benchmark_logs"
     res_logging = run_benchmark(
         problems=first_two,
         optimize_options=optimize_options,
         logging_directory=logging_directory,
-    )
-
-    res_history = run_benchmark(
-        problems=first_two,
-        optimize_options=optimize_options,
     )
 
     expected_keys = {
@@ -35,8 +35,8 @@ def test_run_benchmark_dict_options(tmpdir):
         ("linear_full_rank_bad_start", "tuned_lbfgsb"),
     }
 
-    assert set(res_logging) == expected_keys
     assert set(res_history) == expected_keys
+    assert set(res_logging) == expected_keys
 
 
 def test_run_benchmark_list_options(tmpdir):
@@ -46,16 +46,16 @@ def test_run_benchmark_list_options(tmpdir):
 
     optimize_options = ["scipy_lbfgsb", "scipy_neldermead"]
 
+    res_history = run_benchmark(
+        problems=first_two,
+        optimize_options=optimize_options,
+    )
+
     logging_directory = tmpdir / "benchmark_logs"
     res_logging = run_benchmark(
         problems=first_two,
         optimize_options=optimize_options,
         logging_directory=logging_directory,
-    )
-
-    res_history = run_benchmark(
-        problems=first_two,
-        optimize_options=optimize_options,
     )
 
     expected_keys = {
@@ -65,13 +65,13 @@ def test_run_benchmark_list_options(tmpdir):
         ("rosenbrock_good_start", "scipy_neldermead"),
     }
 
-    assert set(res_logging) == expected_keys
     assert set(res_history) == expected_keys
+    assert set(res_logging) == expected_keys
 
 
-@pytest.mark.parametrize("failing_name", [("jennrich_sampson"), ("osborne_one")])
-def test_run_benchmark_failing(failing_name, tmpdir):
+def test_run_benchmark_failing(tmpdir):
     all_problems = get_benchmark_problems("more_wild")
+    failing_name = "jennrich_sampson"
     failing = {failing_name: all_problems[failing_name]}
 
     optimize_options = ["scipy_lbfgsb"]

--- a/tests/benchmarking/test_run_benchmark.py
+++ b/tests/benchmarking/test_run_benchmark.py
@@ -133,7 +133,10 @@ def _internal_criterion_pandas(params, criterion):
 
 
 def _internal_criterion_dict(params, criterion):
-    x = params["value"]
+    if "b" in params:
+        x = np.array([params["a"]] + params["b"].flatten().tolist())
+    else:
+        x = params["a"]
     critval = criterion(x)
 
     out = {
@@ -165,15 +168,18 @@ problems_pandas_input = {
 prolems_dict_input = {
     "linear_full_rank_good_start": {
         "criterion": partial(linear_full_rank, dim_out=45),
-        "start_x": {"value": np.ones(9)},
-        "solution_x": {"value": linear_full_rank_solution_x},
+        "start_x": {"a": 1, "b": np.ones((2, 2, 2))},
+        "solution_x": {
+            "a": linear_full_rank_solution_x[0],
+            "b": linear_full_rank_solution_x[1:].reshape(2, 2, 2),
+        },
         "start_criterion": 72,
         "solution_criterion": 36,
     },
     "rosenbrock_good_start": {
         "criterion": rosenbrock,
-        "start_x": {"value": np.array([-1.2, 1])},
-        "solution_x": {"value": np.ones(2)},
+        "start_x": {"a": np.array([-1.2, 1])},
+        "solution_x": {"a": np.ones(2)},
         "start_criterion": 24.2,
         "solution_criterion": 0,
     },

--- a/tests/benchmarking/test_run_benchmark.py
+++ b/tests/benchmarking/test_run_benchmark.py
@@ -121,7 +121,7 @@ def _create_problem_solution_custom(specification):
 
 
 def _internal_criterion_pandas(params, criterion):
-    x = pd.DataFrame(params["value"])
+    x = params["value"].to_numpy()
     critval = criterion(x)
 
     out = {
@@ -133,7 +133,7 @@ def _internal_criterion_pandas(params, criterion):
 
 
 def _internal_criterion_dict(params, criterion):
-    x = {"value": params["value"]}
+    x = params["value"]
     critval = criterion(x)
 
     out = {
@@ -144,40 +144,16 @@ def _internal_criterion_dict(params, criterion):
     return out
 
 
-def _linear_full_rank_pandas(x, dim_out):
-    _x = x["value"].to_numpy()
-    out = linear_full_rank(_x, dim_out)
-    return out
-
-
-def _linear_full_rank_dict(x, dim_out):
-    _x = x["value"]
-    out = linear_full_rank(_x, dim_out)
-    return out
-
-
-def _rosenbrock_pandas(x):
-    _x = x["value"].to_numpy()
-    fvec = rosenbrock(_x)
-    return fvec
-
-
-def _rosenbrock_dict(x):
-    _x = x["value"]
-    fvec = rosenbrock(_x)
-    return fvec
-
-
 problems_pandas_input = {
     "linear_full_rank_good_start": {
-        "criterion": partial(_linear_full_rank_pandas, dim_out=45),
+        "criterion": partial(linear_full_rank, dim_out=45),
         "start_x": pd.DataFrame(np.ones(9), columns=["value"]),
         "solution_x": pd.DataFrame(linear_full_rank_solution_x, columns=["value"]),
         "start_criterion": 72,
         "solution_criterion": 36,
     },
     "rosenbrock_good_start": {
-        "criterion": _rosenbrock_pandas,
+        "criterion": rosenbrock,
         "start_x": pd.DataFrame([-1.2, 1], columns=["value"]),
         "solution_x": pd.DataFrame(np.ones(2), columns=["value"]),
         "start_criterion": 24.2,
@@ -188,14 +164,14 @@ problems_pandas_input = {
 
 prolems_dict_input = {
     "linear_full_rank_good_start": {
-        "criterion": partial(_linear_full_rank_dict, dim_out=45),
+        "criterion": partial(linear_full_rank, dim_out=45),
         "start_x": {"value": np.ones(9)},
-        "solution_x": linear_full_rank_solution_x,
+        "solution_x": {"value": linear_full_rank_solution_x},
         "start_criterion": 72,
         "solution_criterion": 36,
     },
     "rosenbrock_good_start": {
-        "criterion": _rosenbrock_dict,
+        "criterion": rosenbrock,
         "start_x": {"value": np.array([-1.2, 1])},
         "solution_x": {"value": np.ones(2)},
         "start_criterion": 24.2,

--- a/tests/benchmarking/test_run_benchmark.py
+++ b/tests/benchmarking/test_run_benchmark.py
@@ -3,7 +3,7 @@ from estimagic import get_benchmark_problems
 from estimagic.benchmarking.run_benchmark import run_benchmark
 
 
-def test_run_benchmark_dict_options(tmpdir):
+def test_run_benchmark_dict_options():
     all_problems = get_benchmark_problems("more_wild")
     first_two_names = list(all_problems)[:2]
     first_two = {name: all_problems[name] for name in first_two_names}
@@ -16,16 +16,9 @@ def test_run_benchmark_dict_options(tmpdir):
         },
     }
 
-    res_history = run_benchmark(
+    result = run_benchmark(
         problems=first_two,
         optimize_options=optimize_options,
-    )
-
-    logging_directory = tmpdir / "benchmark_logs"
-    res_logging = run_benchmark(
-        problems=first_two,
-        optimize_options=optimize_options,
-        logging_directory=logging_directory,
     )
 
     expected_keys = {
@@ -34,28 +27,19 @@ def test_run_benchmark_dict_options(tmpdir):
         ("linear_full_rank_good_start", "tuned_lbfgsb"),
         ("linear_full_rank_bad_start", "tuned_lbfgsb"),
     }
-
-    assert set(res_history) == expected_keys
-    assert set(res_logging) == expected_keys
+    assert set(result) == expected_keys
 
 
-def test_run_benchmark_list_options(tmpdir):
+def test_run_benchmark_list_options():
     all_problems = get_benchmark_problems("example")
     first_two_names = list(all_problems)[:2]
     first_two = {name: all_problems[name] for name in first_two_names}
 
     optimize_options = ["scipy_lbfgsb", "scipy_neldermead"]
 
-    res_history = run_benchmark(
+    result = run_benchmark(
         problems=first_two,
         optimize_options=optimize_options,
-    )
-
-    logging_directory = tmpdir / "benchmark_logs"
-    res_logging = run_benchmark(
-        problems=first_two,
-        optimize_options=optimize_options,
-        logging_directory=logging_directory,
     )
 
     expected_keys = {
@@ -64,27 +48,18 @@ def test_run_benchmark_list_options(tmpdir):
         ("linear_full_rank_good_start", "scipy_neldermead"),
         ("rosenbrock_good_start", "scipy_neldermead"),
     }
-
-    assert set(res_history) == expected_keys
-    assert set(res_logging) == expected_keys
+    assert set(result) == expected_keys
 
 
-def test_run_benchmark_failing(tmpdir):
+def test_run_benchmark_failing():
     all_problems = get_benchmark_problems("more_wild")
     failing_name = "jennrich_sampson"
     failing = {failing_name: all_problems[failing_name]}
 
     optimize_options = ["scipy_lbfgsb"]
 
-    logging_directory = tmpdir / "benchmark_logs"
     with pytest.warns():
-        res_history = run_benchmark(problems=failing, optimize_options=optimize_options)
-        res_logging = run_benchmark(
-            problems=failing,
-            optimize_options=optimize_options,
-            logging_directory=logging_directory,
-        )
+        result = run_benchmark(problems=failing, optimize_options=optimize_options)
 
     key = (failing_name, "scipy_lbfgsb")
-    assert isinstance(res_history[key]["solution"], str)
-    assert isinstance(res_logging[key]["solution"], str)
+    assert isinstance(result[key]["solution"], str)

--- a/tests/benchmarking/test_run_benchmark.py
+++ b/tests/benchmarking/test_run_benchmark.py
@@ -1,6 +1,17 @@
+from functools import partial
+
+import numpy as np
+import pandas as pd
 import pytest
 from estimagic import get_benchmark_problems
+from estimagic.benchmarking.more_wild import linear_full_rank
+from estimagic.benchmarking.more_wild import linear_full_rank_solution_x
+from estimagic.benchmarking.more_wild import rosenbrock
 from estimagic.benchmarking.run_benchmark import run_benchmark
+
+# ======================================================================================
+# Internal benchmark suite
+# ======================================================================================
 
 
 def test_run_benchmark_dict_options():
@@ -34,7 +45,6 @@ def test_run_benchmark_list_options():
     all_problems = get_benchmark_problems("example")
     first_two_names = list(all_problems)[:2]
     first_two = {name: all_problems[name] for name in first_two_names}
-
     optimize_options = ["scipy_lbfgsb", "scipy_neldermead"]
 
     result = run_benchmark(
@@ -63,3 +73,151 @@ def test_run_benchmark_failing():
 
     key = (failing_name, "scipy_lbfgsb")
     assert isinstance(result[key]["solution"], str)
+
+
+# ======================================================================================
+# Custom benchmark functions
+# ======================================================================================
+
+
+def get_benchmark_problems_custom(raw_problems, internal_criterion):
+    problems = {}
+    for name, specification in raw_problems.items():
+        inputs = _create_problem_inputs_custom(specification, internal_criterion)
+
+        problems[name] = {
+            "inputs": inputs,
+            "solution": _create_problem_solution_custom(specification),
+            "info": specification.get("info", {}),
+        }
+
+    return problems
+
+
+def _create_problem_inputs_custom(specification, internal_criterion_func):
+    _criterion = partial(
+        internal_criterion_func,
+        criterion=specification["criterion"],
+    )
+
+    _params = specification["start_x"]
+    inputs = {"criterion": _criterion, "params": _params}
+
+    return inputs
+
+
+def _create_problem_solution_custom(specification):
+    _solution_x = specification.get("solution_x")
+    if _solution_x is None:
+        _solution_x = specification["start_x"] * np.nan
+
+    _value = specification["solution_criterion"]
+
+    solution = {
+        "params": _solution_x,
+        "value": _value,
+    }
+    return solution
+
+
+def _internal_criterion_pandas(params, criterion):
+    x = pd.DataFrame(params["value"])
+    critval = criterion(x)
+
+    out = {
+        "root_contributions": critval,
+        "value": critval @ critval,
+    }
+
+    return out
+
+
+def _internal_criterion_dict(params, criterion):
+    x = {"value": params["value"]}
+    critval = criterion(x)
+
+    out = {
+        "root_contributions": critval,
+        "value": critval @ critval,
+    }
+
+    return out
+
+
+def _linear_full_rank_pandas(x, dim_out):
+    _x = x["value"].to_numpy()
+    out = linear_full_rank(_x, dim_out)
+    return out
+
+
+def _linear_full_rank_dict(x, dim_out):
+    _x = x["value"]
+    out = linear_full_rank(_x, dim_out)
+    return out
+
+
+def _rosenbrock_pandas(x):
+    _x = x["value"].to_numpy()
+    fvec = rosenbrock(_x)
+    return fvec
+
+
+def _rosenbrock_dict(x):
+    _x = x["value"]
+    fvec = rosenbrock(_x)
+    return fvec
+
+
+problems_pandas_input = {
+    "linear_full_rank_good_start": {
+        "criterion": partial(_linear_full_rank_pandas, dim_out=45),
+        "start_x": pd.DataFrame(np.ones(9), columns=["value"]),
+        "solution_x": pd.DataFrame(linear_full_rank_solution_x, columns=["value"]),
+        "start_criterion": 72,
+        "solution_criterion": 36,
+    },
+    "rosenbrock_good_start": {
+        "criterion": _rosenbrock_pandas,
+        "start_x": pd.DataFrame([-1.2, 1], columns=["value"]),
+        "solution_x": pd.DataFrame(np.ones(2), columns=["value"]),
+        "start_criterion": 24.2,
+        "solution_criterion": 0,
+    },
+}
+
+
+prolems_dict_input = {
+    "linear_full_rank_good_start": {
+        "criterion": partial(_linear_full_rank_dict, dim_out=45),
+        "start_x": {"value": np.ones(9)},
+        "solution_x": linear_full_rank_solution_x,
+        "start_criterion": 72,
+        "solution_criterion": 36,
+    },
+    "rosenbrock_good_start": {
+        "criterion": _rosenbrock_dict,
+        "start_x": {"value": np.array([-1.2, 1])},
+        "solution_x": {"value": np.ones(2)},
+        "start_criterion": 24.2,
+        "solution_criterion": 0,
+    },
+}
+
+TEST_CASES = [
+    (problems_pandas_input, _internal_criterion_pandas),
+    (prolems_dict_input, _internal_criterion_dict),
+]
+
+
+@pytest.mark.parametrize("raw_problems, internal_criterion_func", TEST_CASES)
+def test_custom_benchmarks(raw_problems, internal_criterion_func):
+    problems = get_benchmark_problems_custom(raw_problems, internal_criterion_func)
+
+    optimize_options = ["scipy_lbfgsb"]
+    result = run_benchmark(problems=problems, optimize_options=optimize_options)
+
+    expected_keys = {
+        ("linear_full_rank_good_start", "scipy_lbfgsb"),
+        ("rosenbrock_good_start", "scipy_lbfgsb"),
+    }
+    assert set(result) == expected_keys

--- a/tests/benchmarking/test_run_benchmark.py
+++ b/tests/benchmarking/test_run_benchmark.py
@@ -16,11 +16,15 @@ def test_run_benchmark_dict_options(tmpdir):
     }
 
     logging_directory = tmpdir / "benchmark_logs"
-
-    res = run_benchmark(
+    res_logging = run_benchmark(
         problems=first_two,
         optimize_options=optimize_options,
         logging_directory=logging_directory,
+    )
+
+    res_history = run_benchmark(
+        problems=first_two,
+        optimize_options=optimize_options,
     )
 
     expected_keys = {
@@ -30,7 +34,8 @@ def test_run_benchmark_dict_options(tmpdir):
         ("linear_full_rank_bad_start", "tuned_lbfgsb"),
     }
 
-    assert set(res) == expected_keys
+    assert set(res_logging) == expected_keys
+    assert set(res_history) == expected_keys
 
 
 def test_run_benchmark_list_options(tmpdir):
@@ -41,11 +46,15 @@ def test_run_benchmark_list_options(tmpdir):
     optimize_options = ["scipy_lbfgsb", "scipy_neldermead"]
 
     logging_directory = tmpdir / "benchmark_logs"
-
-    res = run_benchmark(
+    res_logging = run_benchmark(
         problems=first_two,
         optimize_options=optimize_options,
         logging_directory=logging_directory,
+    )
+
+    res_history = run_benchmark(
+        problems=first_two,
+        optimize_options=optimize_options,
     )
 
     expected_keys = {
@@ -55,4 +64,5 @@ def test_run_benchmark_list_options(tmpdir):
         ("rosenbrock_good_start", "scipy_neldermead"),
     }
 
-    assert set(res) == expected_keys
+    assert set(res_logging) == expected_keys
+    assert set(res_history) == expected_keys

--- a/tests/visualization/test_convergence_plot.py
+++ b/tests/visualization/test_convergence_plot.py
@@ -35,7 +35,6 @@ def test_convergence_plot_options(options, grid):
         problems,
         optimizers,
         n_cores=1,  # must be 1 for the test to work
-        logging_directory="logging",
     )
 
     convergence_plot(

--- a/tests/visualization/test_profile_plot.py
+++ b/tests/visualization/test_profile_plot.py
@@ -73,16 +73,16 @@ def test_create_solution_times_walltime():
     df = pd.DataFrame(
         columns=["problem", "algorithm", "n_evaluations", "walltime"],
         data=[
-            ["prob1", "algo1", 0, pd.Timedelta(seconds=0)],
-            ["prob1", "algo1", 1, pd.Timedelta(seconds=1)],
+            ["prob1", "algo1", 0, 0],
+            ["prob1", "algo1", 1, 1],
             #
-            ["prob1", "algo2", 2, pd.Timedelta(seconds=2)],
-            ["prob1", "algo2", 3, pd.Timedelta(seconds=3)],
+            ["prob1", "algo2", 2, 2],
+            ["prob1", "algo2", 3, 3],
             #
-            ["prob2", "algo1", 5, pd.Timedelta(seconds=5)],
+            ["prob2", "algo1", 5, 5],
             #
-            ["prob2", "algo2", 0, pd.Timedelta(seconds=0)],
-            ["prob2", "algo2", 1, pd.Timedelta(seconds=1)],
+            ["prob2", "algo2", 0, 0],
+            ["prob2", "algo2", 1, 1],
         ],
     )
     info = pd.DataFrame(
@@ -94,8 +94,8 @@ def test_create_solution_times_walltime():
     )
     expected = pd.DataFrame(
         {
-            "algo1": [pd.Timedelta(seconds=1), pd.Timedelta(seconds=5)],
-            "algo2": [pd.Timedelta(seconds=3), pd.Timedelta(weeks=1000)],
+            "algo1": [1, 5],
+            "algo2": [3, np.inf],
         },
         index=pd.Index(["prob1", "prob2"], name="problem"),
     )

--- a/tests/visualization/test_profile_plot.py
+++ b/tests/visualization/test_profile_plot.py
@@ -130,7 +130,6 @@ def test_profile_plot_options(options):
         problems,
         optimizers,
         n_cores=1,  # must be 1 for the test to work
-        logging_directory="logging",
     )
 
     profile_plot(problems=problems, results=results, **options)


### PR DESCRIPTION
This PR improves estimagic's benchmarking functionality and closes #314. 

To-Dos:
- [x] Add option to read results from history rather than log database
- [x] Get rid of argument ``logging_directory`` and adjust [``_process_optimize_options``](https://github.com/OpenSourceEconomics/estimagic/blob/b97c488b1444c8784a4c65cced3dd45778866f34/src/estimagic/benchmarking/run_benchmark.py#L130)
- [x] Write info on flat ``external_x`` into history
- [x] Rewrite processing of the optimization histories for general pytrees
- [x] Add a fast path in case that parameters are numpy arrays
- [x] Add tests for criterion functions that take ``dict`` as input and return type
- [x] Adjust ``convergence_plot``
- [x] Adjust ``profile_plot``
- [x] Replace ``datetime.now()`` with [``time.perf_counter``](https://docs.python.org/3.5/library/time.html#time.perf_counter)