### PR TITLE
Multiple fixes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,12 @@ releases are available on `Anaconda.org
 <https://anaconda.org/OpenSourceEconomics/estimagic>`_.
 
 
+0.3.1
+-----
+
+- :gh:`349` fixes multiple small bugs and adds test cases for all of them
+  (:ghuser:`mpetrosian`, :ghuser:`janosg` and :ghuser:`timmens`)
+
 0.3.0
 -----
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -101,7 +101,7 @@ provides functionality to perform statistical inference on estimated parameters.
                             </p>
                         </div>
                     </div>
-                 </a>
+                </a>
             </div>
         </div>
     </div>

--- a/src/estimagic/estimation/estimate_ml.py
+++ b/src/estimagic/estimation/estimate_ml.py
@@ -27,6 +27,7 @@ from estimagic.parameters.conversion import Converter
 from estimagic.parameters.conversion import get_converter
 from estimagic.shared.check_option_dicts import check_numdiff_options
 from estimagic.shared.check_option_dicts import check_optimization_options
+from estimagic.utilities import to_pickle
 
 
 def estimate_ml(
@@ -737,3 +738,12 @@ class LikelihoodResult:
         out = self._converter.params_from_internal(helper)
 
         return out
+
+    def to_pickle(self, path):
+        """Save the LikelihoodResult object to pickle.
+
+        Args:
+            path (str, pathlib.Path): A str or pathlib.path ending in .pkl or .pickle.
+
+        """
+        to_pickle(self, path=path)

--- a/src/estimagic/estimation/estimate_ml.py
+++ b/src/estimagic/estimation/estimate_ml.py
@@ -212,7 +212,7 @@ def estimate_ml(
     # Get the converter for params and function outputs
     # ==================================================================================
 
-    converter, flat_estimates = get_converter(
+    converter, internal_estimates = get_converter(
         func=loglike,
         params=estimates,
         constraints=constraints,
@@ -242,9 +242,9 @@ def estimate_ml(
 
         jac_res = first_derivative(
             func=func,
-            params=flat_estimates.values,
-            lower_bounds=flat_estimates.lower_bounds,
-            upper_bounds=flat_estimates.upper_bounds,
+            params=internal_estimates.values,
+            lower_bounds=internal_estimates.lower_bounds,
+            upper_bounds=internal_estimates.upper_bounds,
             **numdiff_options,
         )
 
@@ -285,9 +285,9 @@ def estimate_ml(
 
         hess_res = second_derivative(
             func=func,
-            params=flat_estimates.values,
-            lower_bounds=flat_estimates.lower_bounds,
-            upper_bounds=flat_estimates.upper_bounds,
+            params=internal_estimates.values,
+            lower_bounds=internal_estimates.lower_bounds,
+            upper_bounds=internal_estimates.upper_bounds,
             **numdiff_options,
         )
         int_hess = hess_res["derivative"]
@@ -336,7 +336,7 @@ def estimate_ml(
         _internal_jacobian=int_jac,
         _internal_hessian=int_hess,
         _design_info=design_info,
-        _flat_params=flat_estimates,
+        _flat_params=internal_estimates,
         _has_constraints=constraints not in [None, []],
     )
 
@@ -616,7 +616,7 @@ class LikelihoodResult:
 
         summary = calculate_inference_quantities(
             estimates=self.params,
-            flat_estimates=self._flat_params,
+            internal_estimates=self._flat_params,
             free_cov=free_cov,
             ci_level=ci_level,
         )

--- a/src/estimagic/estimation/estimate_ml.py
+++ b/src/estimagic/estimation/estimate_ml.py
@@ -82,7 +82,7 @@ def estimate_ml(
         upper_bounds (pytree): As lower_bounds. Can be ``np.inf`` for parameters with
             no upper bound.
         constraints (list, dict): List with constraint dictionaries or single dict.
-            See .. _link: ../../docs/source/how_to_guides/how_to_use_constraints.ipynb
+            See :ref:`constraints`.
         logging (pathlib.Path, str or False): Path to sqlite3 file (which typically has
             the file extension ``.db``. If the file does not exist, it will be created.
             The dashboard can only be used when logging is used.

--- a/src/estimagic/estimation/estimate_msm.py
+++ b/src/estimagic/estimation/estimate_msm.py
@@ -108,7 +108,7 @@ def estimate_msm(
             Note that "optimal" refers to the asymptotically optimal weighting matrix
             and is often not a good choice due to large finite sample bias.
         constraints (list, dict): List with constraint dictionaries or single dict.
-            See .. _link: ../../docs/source/how_to_guides/how_to_use_constraints.ipynb
+            See :ref:`constraints`.
         logging (pathlib.Path, str or False): Path to sqlite3 file (which typically has
             the file extension ``.db``. If the file does not exist, it will be created.
             The dashboard can only be used when logging is used.

--- a/src/estimagic/estimation/estimate_msm.py
+++ b/src/estimagic/estimation/estimate_msm.py
@@ -39,6 +39,7 @@ from estimagic.sensitivity.msm_sensitivity import calculate_sensitivity_to_bias
 from estimagic.sensitivity.msm_sensitivity import calculate_sensitivity_to_weighting
 from estimagic.shared.check_option_dicts import check_numdiff_options
 from estimagic.shared.check_option_dicts import check_optimization_options
+from estimagic.utilities import to_pickle
 from pybaum import leaf_names
 from pybaum import tree_just_flatten
 
@@ -930,3 +931,12 @@ class MomentsResult:
             )
             raise ValueError(msg)
         return out
+
+    def to_pickle(self, path):
+        """Save the MomentsResult object to pickle.
+
+        Args:
+            path (str, pathlib.Path): A str or pathlib.path ending in .pkl or .pickle.
+
+        """
+        to_pickle(self, path=path)

--- a/src/estimagic/estimation/estimate_msm.py
+++ b/src/estimagic/estimation/estimate_msm.py
@@ -260,7 +260,7 @@ def estimate_msm(
     else:
         func_eval = {"contributions": sim_mom_eval}
 
-    converter, flat_estimates = get_converter(
+    converter, internal_estimates = get_converter(
         func=helper,
         params=estimates,
         constraints=constraints,
@@ -290,9 +290,9 @@ def estimate_msm(
 
         int_jac = first_derivative(
             func=func,
-            params=flat_estimates.values,
-            lower_bounds=flat_estimates.lower_bounds,
-            upper_bounds=flat_estimates.upper_bounds,
+            params=internal_estimates.values,
+            lower_bounds=internal_estimates.lower_bounds,
+            upper_bounds=internal_estimates.upper_bounds,
             **numdiff_options,
         )["derivative"]
 
@@ -321,7 +321,7 @@ def estimate_msm(
     res = MomentsResult(
         params=estimates,
         weights=weights,
-        _flat_params=flat_estimates,
+        _flat_params=internal_estimates,
         _converter=converter,
         _internal_weights=internal_weights,
         _internal_moments_cov=internal_moments_cov,
@@ -660,7 +660,7 @@ class MomentsResult:
 
         summary = calculate_inference_quantities(
             estimates=self.params,
-            flat_estimates=self._flat_params,
+            internal_estimates=self._flat_params,
             free_cov=free_cov,
             ci_level=ci_level,
         )

--- a/src/estimagic/inference/shared.py
+++ b/src/estimagic/inference/shared.py
@@ -106,9 +106,10 @@ def calculate_inference_quantities(estimates, internal_estimates, free_cov, ci_l
     ####################################################################################
     # Construct summary data frame for flat estimates
     ####################################################################################
+    registry = get_registry(extended=True)
 
     df = pd.DataFrame(index=internal_estimates.names)
-    df["value"] = internal_estimates.values
+    df["value"] = tree_just_flatten(estimates, registry=registry)
     df.loc[free_cov.index, "standard_error"] = np.sqrt(np.diag(free_cov))
 
     df["p_value"] = calculate_p_values(
@@ -134,13 +135,11 @@ def calculate_inference_quantities(estimates, internal_estimates, free_cov, ci_l
     # Map summary data into params tree structure
     ####################################################################################
 
-    registry = get_registry(extended=True)
-
     # create tree with values corresponding to indices of df
     indices = tree_unflatten(estimates, internal_estimates.names, registry=registry)
 
-    indices_flat = tree_just_flatten(indices)
     estimates_flat = tree_just_flatten(estimates)
+    indices_flat = tree_just_flatten(indices)
 
     # use index chunks in indices_flat to access the corresponding sub data frame of df,
     # and use the index information stored in estimates_flat to form the correct (multi)

--- a/src/estimagic/inference/shared.py
+++ b/src/estimagic/inference/shared.py
@@ -22,7 +22,7 @@ def transform_covariance(
             internal parameter vector. For background information about internal and
             external params see :ref:`implementation_of_constraints`.
         constraints (list): List with constraint dictionaries.
-            See .. _link: ../../docs/source/how_to_guides/how_to_use_constraints.ipynb
+            See :ref:`constraints`.
         n_samples (int): Number of samples used to transform the covariance matrix of
             the internal parameter vector into the covariance matrix of the external
             parameters.

--- a/src/estimagic/inference/shared.py
+++ b/src/estimagic/inference/shared.py
@@ -78,13 +78,13 @@ def transform_covariance(
     return free_cov
 
 
-def calculate_inference_quantities(estimates, flat_estimates, free_cov, ci_level):
+def calculate_inference_quantities(estimates, internal_estimates, free_cov, ci_level):
     """Add standard errors, pvalues and confidence intervals to params.
 
     Args
         params (pytree): The input parameter pytree.
-        flat_estimates (FlatParams): NamedTuple with internal estimated parameter values
-            and names, lower_bounds and upper_bounds, and free_mask.
+        internal_estimates (FlatParams): NamedTuple with internal estimated parameter
+            values and names, lower_bounds and upper_bounds, and free_mask.
         free_cov (pd.DataFrame): Quadratic DataFrame containing the covariance matrix
             of the free parameters. If parameters were fixed (explicitly or by other
             constraints) the index is a subset of params.index. The columns are the same
@@ -101,14 +101,14 @@ def calculate_inference_quantities(estimates, flat_estimates, free_cov, ci_level
 
     """
     if not isinstance(free_cov, pd.DataFrame):
-        free_index = np.array(flat_estimates.names)[flat_estimates.free_mask]
+        free_index = np.array(internal_estimates.names)[internal_estimates.free_mask]
         free_cov = pd.DataFrame(data=free_cov, columns=free_index, index=free_index)
     ####################################################################################
     # Construct summary data frame for flat estimates
     ####################################################################################
 
-    df = pd.DataFrame(index=flat_estimates.names)
-    df["value"] = flat_estimates.values
+    df = pd.DataFrame(index=internal_estimates.names)
+    df["value"] = internal_estimates.values
     df.loc[free_cov.index, "standard_error"] = np.sqrt(np.diag(free_cov))
 
     df["p_value"] = calculate_p_values(
@@ -137,7 +137,7 @@ def calculate_inference_quantities(estimates, flat_estimates, free_cov, ci_level
     registry = get_registry(extended=True)
 
     # create tree with values corresponding to indices of df
-    indices = tree_unflatten(estimates, flat_estimates.names, registry=registry)
+    indices = tree_unflatten(estimates, internal_estimates.names, registry=registry)
 
     indices_flat = tree_just_flatten(indices)
     estimates_flat = tree_just_flatten(estimates)

--- a/src/estimagic/optimization/optimize.py
+++ b/src/estimagic/optimization/optimize.py
@@ -83,7 +83,7 @@ def maximize(
         soft_upper_bounds (pytree): As soft_lower_bounds.
         criterion_kwargs (dict): Additional keyword arguments for criterion
         constraints (list, dict): List with constraint dictionaries or single dict.
-            See .. _link: ../../docs/source/how_to_guides/how_to_use_constraints.ipynb
+            See :ref:`constraints`.
         algo_options (dict): Algorithm specific configuration of the optimization. See
             :ref:`list_of_algorithms` for supported options of each algorithm.
         derivative (callable): Function that calculates the first derivative
@@ -281,7 +281,7 @@ def minimize(
         soft_upper_bounds (pytree): As soft_lower_bounds.
         criterion_kwargs (dict): Additional keyword arguments for criterion
         constraints (list, dict): List with constraint dictionaries or single dict.
-            See .. _link: ../../docs/source/how_to_guides/how_to_use_constraints.ipynb
+            See :ref:`constraints`.
         algo_options (dict): Algorithm specific configuration of the optimization. See
             :ref:`list_of_algorithms` for supported options of each algorithm.
         derivative (callable): Function that calculates the first derivative

--- a/src/estimagic/optimization/optimize_result.py
+++ b/src/estimagic/optimization/optimize_result.py
@@ -6,6 +6,7 @@ from typing import Union
 
 import numpy as np
 import pandas as pd
+from estimagic.utilities import to_pickle
 
 
 @dataclass
@@ -87,6 +88,15 @@ class OptimizeResult:
         msg = "\n\n".join(sections)
 
         return msg
+
+    def to_pickle(self, path):
+        """Save the OptimizeResult object to pickle.
+
+        Args:
+            path (str, pathlib.Path): A str or pathlib.path ending in .pkl or .pickle.
+
+        """
+        to_pickle(self, path=path)
 
 
 def _format_convergence_report(report, algorithm):

--- a/src/estimagic/parameters/consolidate_constraints.py
+++ b/src/estimagic/parameters/consolidate_constraints.py
@@ -208,7 +208,7 @@ def _consolidate_fixes_with_equality_constraints(
             assert (
                 len(valcounts) == 1
             ), "Equality constrained parameters cannot be fixed to different values."
-            fixed_value[eq["index"]] = valcounts.index[0]
+            fixed_value[eq["index"]] = valcounts[0]
 
     return fixed_value
 

--- a/src/estimagic/parameters/process_selectors.py
+++ b/src/estimagic/parameters/process_selectors.py
@@ -1,3 +1,4 @@
+import warnings
 from collections import Counter
 
 import numpy as np
@@ -53,7 +54,9 @@ def process_selectors(constraints, params, tree_converter, param_names):
             registry=registry,
         )
         try:
-            selected = evaluator(helper)
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", category=pd.errors.PerformanceWarning)
+                selected = evaluator(helper)
         except (KeyboardInterrupt, SystemExit):
             raise
         except Exception as e:

--- a/src/estimagic/parameters/process_selectors.py
+++ b/src/estimagic/parameters/process_selectors.py
@@ -97,11 +97,13 @@ def _get_selection_field(constraint, selector_case, params_case):
             "dataframe": {"locs", "queries", "selectors"},
             "numpy array": {"locs", "selectors"},
             "pytree": {"selectors"},
+            "series": {"locs", "selectors"},
         },
         "one selector": {
             "dataframe": {"loc", "query", "selector"},
             "numpy array": {"loc", "selector"},
             "pytree": {"selector"},
+            "series": {"loc", "selector"},
         },
     }
 
@@ -183,6 +185,8 @@ def _get_selection_evaluator(field, constraint, params_case, registry):
 def _get_params_case(params):
     if isinstance(params, pd.DataFrame) and "value" in params:
         params_case = "dataframe"
+    elif isinstance(params, pd.Series):
+        params_case = "series"
     elif isinstance(params, np.ndarray):
         params_case = "numpy array"
     else:

--- a/src/estimagic/utilities.py
+++ b/src/estimagic/utilities.py
@@ -1,7 +1,9 @@
 import warnings
 from hashlib import sha1
 
+import cloudpickle
 import numpy as np
+import pandas as pd
 from scipy.linalg import ldl
 from scipy.linalg import qr
 
@@ -282,3 +284,12 @@ def calculate_trustregion_initial_radius(x):
     """
     x_norm = np.linalg.norm(x, ord=np.inf)
     return 0.1 * max(x_norm, 1)
+
+
+def to_pickle(obj, path):
+    with open(path, "wb") as buffer:
+        cloudpickle.dump(obj, buffer)
+
+
+def read_pickle(path):
+    return pd.read_pickle(path)

--- a/src/estimagic/utilities.py
+++ b/src/estimagic/utilities.py
@@ -2,9 +2,12 @@ import warnings
 from hashlib import sha1
 
 import numpy as np
-from fuzzywuzzy import process as fw_process
 from scipy.linalg import ldl
 from scipy.linalg import qr
+
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore", category=UserWarning)
+    from fuzzywuzzy import process as fw_process
 
 
 def chol_params_to_lower_triangular_matrix(params):
@@ -125,7 +128,9 @@ def propose_alternatives(requested, possibilities, number=3):
 
     """
     number = min(number, len(possibilities))
-    proposals_w_probs = fw_process.extract(requested, possibilities, limit=number)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=UserWarning)
+        proposals_w_probs = fw_process.extract(requested, possibilities, limit=number)
     proposals = [proposal[0] for proposal in proposals_w_probs]
 
     return proposals

--- a/src/estimagic/visualization/estimation_table.py
+++ b/src/estimagic/visualization/estimation_table.py
@@ -322,6 +322,7 @@ def render_latex(
     default_options = {
         "multicol_align": "c",
         "hrules": True,
+        "siunitx": True,
         "column_format": "l" * n_levels + "S" * n_columns,
     }
     if render_options:

--- a/src/estimagic/visualization/estimation_table.py
+++ b/src/estimagic/visualization/estimation_table.py
@@ -285,7 +285,7 @@ def render_latex(
             r"""Proper LaTeX compilation requires the package siunitx and adding
                    \sisetup{
                        input-symbols            = (),
-                       table-align-text-post    = false
+                       table-align-text-post    = false,
                        group-digits             = false,
                     }
                     to your main tex file. To turn

--- a/src/estimagic/visualization/slice_plot.py
+++ b/src/estimagic/visualization/slice_plot.py
@@ -155,7 +155,10 @@ def slice_plot(
     )
 
     # add NaNs where an evaluation failed
-    func_values = [val if not isinstance(val, str) else np.nan for val in func_values]
+    func_values = [
+        converter.func_to_internal(val) if not isinstance(val, str) else np.nan
+        for val in func_values
+    ]
 
     func_values += [converter.func_to_internal(func_eval)] * len(selected)
     for pos in selected:

--- a/tests/estimation/test_estimate_ml.py
+++ b/tests/estimation/test_estimate_ml.py
@@ -298,3 +298,21 @@ def test_estimate_ml_general_pytree(normal_inputs):
         np.abs(true["mean"] - got.summary(method="jacobian")["mean"]["value"][0]) < 1e-1
     )
     assert np.abs(true["sd"] - got.summary(method="jacobian")["sd"]["value"][0]) < 1e-1
+
+
+def test_to_pickle(normal_inputs, tmp_path):
+    kwargs = {"y": normal_inputs["y"]}
+
+    start_params = {"mean": 5, "sd": 3}
+
+    got = estimate_ml(
+        loglike=normal_loglike,
+        params=start_params,
+        loglike_kwargs=kwargs,
+        optimize_options="scipy_lbfgsb",
+        lower_bounds={"sd": 0.0001},
+        jacobian_kwargs=kwargs,
+        constraints=[{"selector": lambda p: p["sd"], "type": "sdcorr"}],
+    )
+
+    got.to_pickle(tmp_path / "bla.pkl")

--- a/tests/estimation/test_estimate_ml.py
+++ b/tests/estimation/test_estimate_ml.py
@@ -36,7 +36,6 @@ def multivariate_normal_loglike(params, data):
     }
 
 
-@pytest.mark.tryfirst
 def test_estimate_ml_with_constraints():
 
     # true parameters

--- a/tests/estimation/test_estimate_msm.py
+++ b/tests/estimation/test_estimate_msm.py
@@ -157,3 +157,22 @@ def test_estimate_msm_with_jacobian():
 
     aaae(calculated.params, expected_params)
     aaae(calculated.cov(), cov_np)
+
+
+def test_to_pickle(tmp_path):
+    start_params = np.array([3, 2, 1])
+
+    # abuse simulate_moments to get empirical moments in correct format
+    empirical_moments = _sim_np(np.zeros(3))
+    if isinstance(empirical_moments, dict):
+        empirical_moments = empirical_moments["simulated_moments"]
+
+    calculated = estimate_msm(
+        simulate_moments=_sim_np,
+        empirical_moments=empirical_moments,
+        moments_cov=cov_np,
+        params=start_params,
+        optimize_options="scipy_lbfgsb",
+    )
+
+    calculated.to_pickle(tmp_path / "bla.pkl")

--- a/tests/optimization/test_optimize_result.py
+++ b/tests/optimization/test_optimize_result.py
@@ -62,3 +62,12 @@ def test_create_stars():
     calculated = _create_stars(sr).tolist()
     expected = ["***", "** ", "*  ", "   ", "   "]
     assert calculated == expected
+
+
+def test_to_pickle(base_inputs, convergence_report, tmp_path):
+
+    res = OptimizeResult(
+        convergence_report=convergence_report,
+        **base_inputs,
+    )
+    res.to_pickle(tmp_path / "bla.pkl")

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -10,11 +10,13 @@ from estimagic.utilities import cov_to_sds_and_corr
 from estimagic.utilities import dimension_to_number_of_triangular_elements
 from estimagic.utilities import hash_array
 from estimagic.utilities import number_of_triangular_elements_to_dimension
+from estimagic.utilities import read_pickle
 from estimagic.utilities import robust_cholesky
 from estimagic.utilities import robust_inverse
 from estimagic.utilities import sdcorr_params_to_matrix
 from estimagic.utilities import sdcorr_params_to_sds_and_corr
 from estimagic.utilities import sds_and_corr_to_cov
+from estimagic.utilities import to_pickle
 from numpy.testing import assert_array_almost_equal as aaae
 
 
@@ -166,3 +168,11 @@ def test_initial_trust_radius_large_x():
     expected = 2.05
     res = calculate_trustregion_initial_radius(x)
     assert expected == pytest.approx(res, abs=1e-8)
+
+
+def test_pickling(tmp_path):
+    a = [1, 2, 3]
+    path = tmp_path / "bla.pkl"
+    to_pickle(a, path)
+    b = read_pickle(path)
+    assert a == b

--- a/tests/visualization/test_slice_plot.py
+++ b/tests/visualization/test_slice_plot.py
@@ -5,21 +5,26 @@ from estimagic.visualization.slice_plot import slice_plot
 
 @pytest.fixture
 def fixed_inputs():
-    def sphere(params):
-        x = np.array(list(params.values()))
-        return x @ x
-
     params = {"alpha": 0, "beta": 0, "gamma": 0, "delta": 0}
     lower_bounds = {name: -5 for name in params}
     upper_bounds = {name: i + 2 for i, name in enumerate(params)}
 
     out = {
-        "func": sphere,
         "params": params,
         "lower_bounds": lower_bounds,
         "upper_bounds": upper_bounds,
     }
     return out
+
+
+def sphere_with_contributions(params):
+    x = np.array(list(params.values()))
+    return {"value": x @ x, "contributions": x**2}
+
+
+def sphere(params):
+    x = np.array(list(params.values()))
+    return x @ x
 
 
 KWARGS = [
@@ -31,12 +36,16 @@ KWARGS = [
     {"share_y": False},
     {"return_dict": True},
 ]
+parametrization = [
+    (func, kwargs) for func in [sphere_with_contributions, sphere] for kwargs in KWARGS
+]
 
 
-@pytest.mark.parametrize("kwargs", KWARGS)
-def test_slice_plot(fixed_inputs, kwargs):
+@pytest.mark.parametrize("func, kwargs", parametrization)
+def test_slice_plot(fixed_inputs, func, kwargs):
 
     slice_plot(
+        func=func,
         **fixed_inputs,
         **kwargs,
     )


### PR DESCRIPTION
Fixes and tests for multiple edge cases that were not covered before

- Supress pandas performance warning during constraint processing
- Supress fuzzywuzzy performance warning
- Fix bug in consolidate constraint that lead to an exception if equality constraints and fixes are overlapping
- Add cloudpickle based `to_pickle` method to estimation results. This is necessary because standard pickle would fail. For consistency, we also add it to optimization result. 
- Fix a bug in generation of estimation `summary` dataframe; This could have lead to wrong results (internal instead of external parameter values) if both parameter vectors have the same length. It lead to exceptions otherwise. 
- Allow for functions that return dictionaries in slice_plot.
- Fix a small bug in `render_latex`.