### PR TITLE
Update InvalidParamsError message for constraints

### DIFF
--- a/src/estimagic/parameters/check_constraints.py
+++ b/src/estimagic/parameters/check_constraints.py
@@ -91,7 +91,11 @@ def check_constraints_are_satisfied(flat_constraints, param_values, param_names)
 
 
 def _get_message(constraint, param_names, explanation=""):
-    start = f"A constraint of type '{constraint['type']}' is not fulfilled in params."
+    start = (
+        f"A constraint of type '{constraint['type']}' is not fulfilled in params, "
+        "please make sure that it holds for the starting values. The problem arose "
+        "because:"
+    )
 
     if explanation:
         explanation = f" {explanation.rstrip('. ')}. "


### PR DESCRIPTION
Print better error message for invalid starting parameters with constraints.