### PR TITLE
Tranquilo cleanup

### DIFF
--- a/src/estimagic/optimization/tranquilo/bounds.py
+++ b/src/estimagic/optimization/tranquilo/bounds.py
@@ -1,0 +1,27 @@
+from dataclasses import dataclass, replace
+
+import numpy as np
+
+
+@dataclass
+class Bounds:
+    """Parameter bounds."""
+
+    lower: np.ndarray
+    upper: np.ndarray
+
+    def __post_init__(self):
+        self.has_any = _any_finite(self.lower, self.upper)
+
+    # make it behave like a NamedTuple
+    def _replace(self, **kwargs):
+        return replace(self, **kwargs)
+
+
+def _any_finite(lb, ub):
+    out = False
+    if lb is not None and np.isfinite(lb).any():
+        out = True
+    if ub is not None and np.isfinite(ub).any():
+        out = True
+    return out

--- a/src/estimagic/optimization/tranquilo/bounds.py
+++ b/src/estimagic/optimization/tranquilo/bounds.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass, replace
 import numpy as np
 
 
-@dataclass
+@dataclass(frozen=True)
 class Bounds:
     """Parameter bounds."""
 
@@ -11,7 +11,8 @@ class Bounds:
     upper: np.ndarray
 
     def __post_init__(self):
-        self.has_any = _any_finite(self.lower, self.upper)
+        # cannot use standard __setattr__ because it is frozen
+        super().__setattr__("has_any", _any_finite(self.lower, self.upper))
 
     # make it behave like a NamedTuple
     def _replace(self, **kwargs):

--- a/src/estimagic/optimization/tranquilo/estimate_variance.py
+++ b/src/estimagic/optimization/tranquilo/estimate_variance.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from estimagic.optimization.tranquilo.get_component import get_component
 from estimagic.optimization.tranquilo.new_history import History
-from estimagic.optimization.tranquilo.options import Region
+from estimagic.optimization.tranquilo.region import Region
 
 
 def get_variance_estimator(fitter, user_options):

--- a/src/estimagic/optimization/tranquilo/fit_models.py
+++ b/src/estimagic/optimization/tranquilo/fit_models.py
@@ -327,7 +327,7 @@ def fit_powell(x, y, model_type):
     elif n_samples >= _n_just_identified:
         coef = fit_ols(x, y, weights=None, model_type=model_type)
     else:
-        coef = _fit_minimal_frobenius_norm_of_hessian(x, y, model_type)
+        coef = _fit_minimal_frobenius_norm_of_hessian(x, y)
 
     return coef
 

--- a/src/estimagic/optimization/tranquilo/models.py
+++ b/src/estimagic/optimization/tranquilo/models.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, replace
-from typing import NamedTuple, Union
+from typing import Union
 
 import numpy as np
 from numba import njit
@@ -39,11 +39,6 @@ class ScalarModel:
     # make it behave like a NamedTuple
     def _replace(self, **kwargs):
         return replace(self, **kwargs)
-
-
-class ModelInfo(NamedTuple):
-    has_squares: bool = True
-    has_interactions: bool = True
 
 
 def _predict_vector(model: VectorModel, centered_x: np.ndarray) -> np.ndarray:
@@ -308,25 +303,12 @@ def _predict_scalar(model: ScalarModel, centered_x: np.ndarray) -> np.ndarray:
     return out
 
 
-def n_free_params(dim, info_or_name):
+def n_free_params(dim, model_type):
     """Number of free parameters in a model specified by name or model_info."""
     out = dim + 1
-    if isinstance(info_or_name, ModelInfo):
-        info = info_or_name
-        if info.has_squares:
-            out += dim
-        if info.has_interactions:
-            out += n_interactions(dim)
-    elif isinstance(info_or_name, str) and info_or_name in (
-        "linear",
-        "quadratic",
-        "diagonal",
-    ):
-        name = info_or_name
-        if name == "quadratic":
+    if model_type in ("linear", "quadratic"):
+        if model_type == "quadratic":
             out += n_second_order_terms(dim)
-        elif name == "diagonal":
-            out += dim
     else:
         raise ValueError()
     return out
@@ -346,12 +328,10 @@ def n_interactions(dim):
 
 def is_second_order_model(model_or_info):
     """Check if a model has any second order terms."""
-    if isinstance(model_or_info, ModelInfo):
-        model_info = model_or_info
-        out = model_info.has_interactions or model_info.has_squares
+    if isinstance(model_or_info, str):
+        out = model_or_info == "quadratic"
     elif isinstance(model_or_info, (ScalarModel, VectorModel)):
-        model = model_or_info
-        out = model.square_terms is not None
+        out = model_or_info.square_terms is not None
     else:
         raise TypeError()
     return out

--- a/src/estimagic/optimization/tranquilo/models.py
+++ b/src/estimagic/optimization/tranquilo/models.py
@@ -4,7 +4,7 @@ from typing import Union
 import numpy as np
 from numba import njit
 
-from estimagic.optimization.tranquilo.options import Region
+from estimagic.optimization.tranquilo.region import Region
 
 
 @dataclass

--- a/src/estimagic/optimization/tranquilo/options.py
+++ b/src/estimagic/optimization/tranquilo/options.py
@@ -60,11 +60,6 @@ class Region(NamedTuple):
     shape: str
 
 
-class HistorySearchOptions(NamedTuple):
-    radius_type: str = "inscribed"
-    radius_factor: float = 5
-
-
 class AcceptanceOptions(NamedTuple):
     confidence_level: float = 0.8
     power_level: float = 0.8

--- a/src/estimagic/optimization/tranquilo/options.py
+++ b/src/estimagic/optimization/tranquilo/options.py
@@ -1,4 +1,3 @@
-from dataclasses import dataclass
 from typing import NamedTuple
 
 import numpy as np
@@ -7,17 +6,6 @@ from estimagic.optimization.algo_options import (
     CONVERGENCE_RELATIVE_CRITERION_TOLERANCE,
     CONVERGENCE_RELATIVE_GRADIENT_TOLERANCE,
 )
-
-
-@dataclass
-class Bounds:
-    """Stopping criteria."""
-
-    lower: np.ndarray
-    upper: np.ndarray
-
-    def __post_init__(self):
-        self.has_any = _check_if_there_are_bounds(self.lower, self.upper)
 
 
 class StopOptions(NamedTuple):
@@ -54,12 +42,6 @@ class RadiusOptions(NamedTuple):
     max_radius_to_step_ratio: float = np.inf
 
 
-class Region(NamedTuple):
-    center: np.ndarray
-    radius: float
-    shape: str
-
-
 class AcceptanceOptions(NamedTuple):
     confidence_level: float = 0.8
     power_level: float = 0.8
@@ -76,12 +58,3 @@ class StagnationOptions(NamedTuple):
     sample_increment: int = 1
     max_trials: int = 1
     drop: bool = True
-
-
-def _check_if_there_are_bounds(lb, ub):
-    out = False
-    if lb is not None and np.isfinite(lb).any():
-        out = True
-    if ub is not None and np.isfinite(ub).any():
-        out = True
-    return out

--- a/src/estimagic/optimization/tranquilo/options.py
+++ b/src/estimagic/optimization/tranquilo/options.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from typing import NamedTuple
 
 import numpy as np
@@ -8,11 +9,15 @@ from estimagic.optimization.algo_options import (
 )
 
 
-class Bounds(NamedTuple):
+@dataclass
+class Bounds:
     """Stopping criteria."""
 
     lower: np.ndarray
     upper: np.ndarray
+
+    def __post_init__(self):
+        self.has_any = _check_if_there_are_bounds(self.lower, self.upper)
 
 
 class StopOptions(NamedTuple):
@@ -76,3 +81,12 @@ class StagnationOptions(NamedTuple):
     sample_increment: int = 1
     max_trials: int = 1
     drop: bool = True
+
+
+def _check_if_there_are_bounds(lb, ub):
+    out = False
+    if lb is not None and np.isfinite(lb).any():
+        out = True
+    if ub is not None and np.isfinite(ub).any():
+        out = True
+    return out

--- a/src/estimagic/optimization/tranquilo/region.py
+++ b/src/estimagic/optimization/tranquilo/region.py
@@ -8,7 +8,7 @@ from estimagic.optimization.tranquilo.volume import (
 )
 
 
-@dataclass
+@dataclass(frozen=True)
 class Region:
     """Trust region."""
 
@@ -29,9 +29,7 @@ class Region:
             raise AttributeError(
                 "The trustregion is a sphere, and thus has no cube bounds."
             )
-        radius = get_radius_of_cube_with_volume_of_sphere(
-            self.radius, len(self.center), scaling_factor=1.0
-        )
+        radius = get_radius_of_cube_with_volume_of_sphere(self.radius, len(self.center))
         bounds = _get_cube_bounds(center=self.center, radius=radius, bounds=self.bounds)
         return bounds
 
@@ -41,8 +39,7 @@ class Region:
             raise AttributeError(
                 "The trustregion is a sphere, and thus has no cube center."
             )
-        cube_bounds = self.cube_bounds
-        center = (cube_bounds.lower + cube_bounds.upper) / 2
+        center = _get_cube_center(bounds=self.cube_bounds)
         return center
 
     def map_to_unit(self, x: np.ndarray) -> np.ndarray:
@@ -102,6 +99,12 @@ def _get_cube_bounds(center, radius, bounds):
         upper_bounds = np.clip(upper_bounds, -np.inf, bounds.upper)
 
     return Bounds(lower=lower_bounds, upper=upper_bounds)
+
+
+def _get_cube_center(bounds):
+    """Get center of region defined by bounds."""
+    center = (bounds.lower + bounds.upper) / 2
+    return center
 
 
 def _any_bounds_binding(bounds, center, radius):

--- a/src/estimagic/optimization/tranquilo/region.py
+++ b/src/estimagic/optimization/tranquilo/region.py
@@ -1,0 +1,116 @@
+from dataclasses import dataclass, replace
+
+import numpy as np
+
+from estimagic.optimization.tranquilo.bounds import Bounds
+from estimagic.optimization.tranquilo.volume import (
+    get_radius_of_cube_with_volume_of_sphere,
+)
+
+
+@dataclass
+class Region:
+    """Trust region."""
+
+    center: np.ndarray
+    radius: float
+    bounds: Bounds = None
+
+    @property
+    def shape(self) -> str:
+        any_bounds_binding = _any_bounds_binding(
+            bounds=self.bounds, center=self.center, radius=self.radius
+        )
+        return "cube" if any_bounds_binding else "sphere"
+
+    @property
+    def cube_bounds(self) -> Bounds:
+        if self.shape == "sphere":
+            raise AttributeError(
+                "The trustregion is a sphere, and thus has no cube bounds."
+            )
+        radius = get_radius_of_cube_with_volume_of_sphere(
+            self.radius, len(self.center), scaling_factor=1.0
+        )
+        bounds = _get_cube_bounds(center=self.center, radius=radius, bounds=self.bounds)
+        return bounds
+
+    @property
+    def cube_center(self) -> np.ndarray:
+        if self.shape == "sphere":
+            raise AttributeError(
+                "The trustregion is a sphere, and thus has no cube center."
+            )
+        cube_bounds = self.cube_bounds
+        center = (cube_bounds.lower + cube_bounds.upper) / 2
+        return center
+
+    def map_to_unit(self, x: np.ndarray) -> np.ndarray:
+        """Map points from the trustregion to the unit sphere or cube."""
+        if self.shape == "sphere":
+            out = _map_to_unit_sphere(x, center=self.center, radius=self.radius)
+        else:
+            out = _map_to_unit_cube(x, cube_bounds=self.cube_bounds)
+        return out
+
+    def map_from_unit(self, x: np.ndarray) -> np.ndarray:
+        """Map points from the unit sphere or cube to the trustregion."""
+        if self.shape == "sphere":
+            out = _map_from_unit_sphere(x, center=self.center, radius=self.radius)
+        else:
+            out = _map_from_unit_cube(x, cube_bounds=self.cube_bounds)
+        return out
+
+    # make it behave like a NamedTuple
+    def _replace(self, **kwargs):
+        return replace(self, **kwargs)
+
+
+def _map_to_unit_cube(x, cube_bounds):
+    """Map points from the trustregion to the unit cube."""
+    out = 2 * (x - cube_bounds.lower) / (cube_bounds.upper - cube_bounds.lower) - 1
+    return out
+
+
+def _map_to_unit_sphere(x, center, radius):
+    """Map points from the trustregion to the unit sphere."""
+    out = (x - center) / radius
+    return out
+
+
+def _map_from_unit_cube(x, cube_bounds):
+    """Map points from the unit cube to the trustregion."""
+    out = (cube_bounds.upper - cube_bounds.lower) * (x + 1) / 2 + cube_bounds.lower
+    return out
+
+
+def _map_from_unit_sphere(x, center, radius):
+    """Map points from the unit sphere to the trustregion."""
+    out = x * radius + center
+    return out
+
+
+def _get_cube_bounds(center, radius, bounds):
+    """Get new bounds that define the intersection of the trustregion and the bounds."""
+    lower_bounds = center - radius
+    upper_bounds = center + radius
+
+    if bounds is not None and bounds.lower is not None:
+        lower_bounds = np.clip(lower_bounds, bounds.lower, np.inf)
+
+    if bounds is not None and bounds.upper is not None:
+        upper_bounds = np.clip(upper_bounds, -np.inf, bounds.upper)
+
+    return Bounds(lower=lower_bounds, upper=upper_bounds)
+
+
+def _any_bounds_binding(bounds, center, radius):
+    """Check if any bound is binding, i.e. inside the trustregion."""
+    out = False
+    if bounds is not None and bounds.has_any:
+        if bounds.lower is not None:
+            lower_binding = np.min(center - bounds.lower) <= radius
+        if bounds.upper is not None:
+            upper_binding = np.min(bounds.upper - center) <= radius
+        out = lower_binding or upper_binding
+    return out

--- a/src/estimagic/optimization/tranquilo/sample_points.py
+++ b/src/estimagic/optimization/tranquilo/sample_points.py
@@ -6,10 +6,9 @@ from scipy.special import gammainc, logsumexp
 
 import estimagic as em
 from estimagic.optimization.tranquilo.get_component import get_component
-from estimagic.optimization.tranquilo.options import Bounds
 
 
-def get_sampler(sampler, bounds, model_info=None, user_options=None):
+def get_sampler(sampler, model_info=None, user_options=None):
     """Get sampling function partialled options.
 
     Args:
@@ -19,7 +18,6 @@ def get_sampler(sampler, bounds, model_info=None, user_options=None):
             Sampling functions need to return a dictionary with the entry "points"
             (and arbitrary additional information). See ``reference_sampler`` for
             details.
-        bounds (Bounds): A NamedTuple with attributes ``lower`` and ``upper``
         user_options (dict): Additional keyword arguments for the sampler. Options that
             are not used by the sampler are ignored with a warning. If sampler is
             'hull_sampler' or 'optimal_hull_sampler' the user options must contain the
@@ -56,12 +54,10 @@ def get_sampler(sampler, bounds, model_info=None, user_options=None):
         raise ValueError(msg)
 
     default_options = {
-        "bounds": bounds,
         "model_info": model_info,
     }
 
     mandatory_args = [
-        "bounds",
         "trustregion",
         "n_points",
         "existing_xs",
@@ -85,7 +81,6 @@ def _box_sampler(
     n_points,
     rng,
     existing_xs=None,  # noqa: ARG001
-    bounds=None,
 ):
     """Naive random generation of trustregion points inside a box.
 
@@ -100,28 +95,31 @@ def _box_sampler(
     outside of the sampler.
 
     Args:
-        trustregion (TrustRegion): NamedTuple with attributes center and radius.
+        trustregion (Region): Trustregion. See module region.py.
         n_points (int): how many new points to sample
         rng (numpy.random.Generator): Random number generator.
         existing_xs (np.ndarray or None): 2d numpy array in which each row is an
             x vector at which the criterion function has already been evaluated, that
             satisfies lower_bounds <= existing_xs <= upper_bounds.
-        bounds (Bounds or None): NamedTuple.
 
     """
     n_params = len(trustregion.center)
-    effective_bounds = _get_effective_bounds(trustregion, bounds=bounds)
+
+    bounds = trustregion.cube_bounds
 
     points = rng.uniform(
-        low=effective_bounds.lower,
-        high=effective_bounds.upper,
+        low=bounds.lower,
+        high=bounds.upper,
         size=(n_points, n_params),
     )
     return points
 
 
 def _ball_sampler(
-    trustregion, n_points, rng, existing_xs=None, bounds=None  # noqa: ARG001
+    trustregion,
+    n_points,
+    rng,
+    existing_xs=None,  # noqa: ARG001
 ):
     """Naive random generation of trustregion points inside a ball.
 
@@ -131,24 +129,21 @@ def _ball_sampler(
     Code is adapted from https://tinyurl.com/y3p2dz6b.
 
     Args:
-        trustregion (TrustRegion): NamedTuple with attributes center and radius.
+        trustregion (Region): Trustregion. See module region.py.
         n_points (int): how many new points to sample
         rng (numpy.random.Generator): Random number generator.
         existing_xs (np.ndarray or None): 2d numpy array in which each row is an
             x vector at which the criterion function has already been evaluated, that
             satisfies lower_bounds <= existing_xs <= upper_bounds.
-        bounds (Bounds or None): NamedTuple.
 
     """
     n_params = len(trustregion.center)
-    effective_bounds = _get_effective_bounds(trustregion, bounds=bounds)
 
     raw = rng.normal(size=(n_points, n_params))
     norm = np.linalg.norm(raw, axis=1, ord=2)
     scale = gammainc(n_params / 2, norm**2 / 2) ** (1 / n_params) / norm
     points = raw * scale.reshape(-1, 1)
-
-    out = _map_into_feasible_trustregion(points, bounds=effective_bounds)
+    out = trustregion.map_from_unit(points)
     return out
 
 
@@ -159,7 +154,6 @@ def _hull_sampler(
     order,
     distribution=None,
     existing_xs=None,  # noqa: ARG001
-    bounds=None,
 ):
     """Random generation of trustregion points on the hull of general sphere / cube.
 
@@ -168,7 +162,7 @@ def _hull_sampler(
     defined by the intersection of the trustregion and the bounds.
 
     Args:
-        trustregion (TrustRegion): NamedTuple with attributes center and radius.
+        trustregion (Region): Trustregion. See module region.py.
         n_points (int): how many new points to sample
         rng (numpy.random.Generator): Random number generator.
         order (int): Type of norm to use when scaling the sampled points. For 2 it will
@@ -178,18 +172,16 @@ def _hull_sampler(
         existing_xs (np.ndarray or None): 2d numpy array in which each row is an
             x vector at which the criterion function has already been evaluated, that
             satisfies lower_bounds <= existing_xs <= upper_bounds.
-        bounds (Bounds or None): NamedTuple.
 
     """
     n_params = len(trustregion.center)
-    effective_bounds = _get_effective_bounds(trustregion, bounds=bounds)
 
     if distribution is None:
         distribution = "normal" if order <= 3 else "uniform"
-    points = _draw_from_distribution(distribution, rng=rng, size=(n_points, n_params))
-    points = _project_onto_unit_hull(points, order=order)
-    points = _map_into_feasible_trustregion(points, bounds=effective_bounds)
-    return points
+    raw = _draw_from_distribution(distribution, rng=rng, size=(n_points, n_params))
+    points = _project_onto_unit_hull(raw, order=order)
+    out = trustregion.map_from_unit(points)
+    return out
 
 
 def _optimal_hull_sampler(
@@ -200,7 +192,6 @@ def _optimal_hull_sampler(
     distribution=None,
     hardness=1,
     existing_xs=None,
-    bounds=None,
     algorithm="scipy_lbfgsb",
     algo_options=None,
     criterion=None,
@@ -218,7 +209,7 @@ def _optimal_hull_sampler(
     seek: https://tinyurl.com/mrythbk4.
 
     Args:
-        trustregion (TrustRegion): NamedTuple with attributes center and radius.
+        trustregion (Region): Trustregion. See module region.py.
         n_points (int): how many new points to sample
         rng (numpy.random.Generator): Random number generator.
         order (int): Type of norm to use when scaling the sampled points. For 2 it will
@@ -231,7 +222,6 @@ def _optimal_hull_sampler(
         existing_xs (np.ndarray or None): 2d numpy array in which each row is an
             x vector at which the criterion function has already been evaluated, that
             satisfies lower_bounds <= existing_xs <= upper_bounds.
-        bounds (Bounds or None): NamedTuple.
         algorithm (str): Optimization algorithm.
         algo_options (dict): Algorithm specific configuration of the optimization. See
             :ref:`list_of_algorithms` for supported options of each algorithm. Default
@@ -273,11 +263,10 @@ def _optimal_hull_sampler(
     if "stopping_max_iterations" not in algo_options:
         algo_options["stopping_max_iterations"] = 2 * n_params + 5
 
-    effective_bounds = _get_effective_bounds(trustregion, bounds=bounds)
-
     if existing_xs is not None:
         # map existing points into unit space for easier optimization
-        existing_xs_unit = _map_from_feasible_trustregion(existing_xs, effective_bounds)
+
+        existing_xs_unit = trustregion.map_to_unit(existing_xs)
 
         if criterion == "distance":
             dist_to_center = np.linalg.norm(existing_xs_unit, axis=1)
@@ -348,7 +337,7 @@ def _optimal_hull_sampler(
         opt_params = x0
 
     points = _project_onto_unit_hull(opt_params.reshape(-1, n_params), order=order)
-    points = _map_into_feasible_trustregion(points, bounds=effective_bounds)
+    points = trustregion.map_from_unit(points)
 
     # Collect additional information. Mostly used for testing.
     info = {
@@ -473,38 +462,6 @@ def _draw_from_distribution(distribution, rng, size):
     return draw
 
 
-def _map_into_feasible_trustregion(points, bounds):
-    """Map points from the unit space into trustregion defined by bounds.
-
-    Args:
-        points (np.ndarray): 2d array of points to be mapped. Each value is in [-1, 1].
-        bounds (Bounds): A NamedTuple with attributes ``lower`` and ``upper``, where
-            lower and upper define the rectangle that is the feasible trustregion.
-
-    Returns:
-        np.ndarray: Points in trustregion.
-
-    """
-    out = (bounds.upper - bounds.lower) * (points + 1) / 2 + bounds.lower
-    return out
-
-
-def _map_from_feasible_trustregion(points, bounds):
-    """Map points from a feasible trustregion definde by bounds into unit space.
-
-    Args:
-        points (np.ndarray): 2d array of points to be mapped. Each value is in [-1, 1].
-        bounds (Bounds): A NamedTuple with attributes ``lower`` and ``upper``, where
-            lower and upper define the rectangle that is the feasible trustregion.
-
-    Returns:
-        np.ndarray: Points in unit space.
-
-    """
-    out = 2 * (points - bounds.lower) / (bounds.upper - bounds.lower) - 1
-    return out
-
-
 def _project_onto_unit_hull(x, order):
     """Project points from the unit space onto the hull of a geometric figure.
 
@@ -520,16 +477,3 @@ def _project_onto_unit_hull(x, order):
     norm = np.linalg.norm(x, axis=1, ord=order).reshape(-1, 1)
     projected = x / norm
     return projected
-
-
-def _get_effective_bounds(trustregion, bounds):
-    lower_bounds = trustregion.center - trustregion.radius
-    upper_bounds = trustregion.center + trustregion.radius
-
-    if bounds is not None and bounds.lower is not None:
-        lower_bounds = np.clip(lower_bounds, bounds.lower, np.inf)
-
-    if bounds is not None and bounds.upper is not None:
-        upper_bounds = np.clip(upper_bounds, -np.inf, bounds.upper)
-
-    return Bounds(lower=lower_bounds, upper=upper_bounds)

--- a/src/estimagic/optimization/tranquilo/solve_subproblem.py
+++ b/src/estimagic/optimization/tranquilo/solve_subproblem.py
@@ -56,7 +56,7 @@ def get_subsolver(solver, user_options=None, bounds=None):
                 subproblem ("gqtpar").
             - k_hard (float): Stopping criterion for the "hard" case in the trust-region
                 subproblem ("gqtpar").
-        bounds (NamedTuple or None):
+        bounds (Bounds):
 
     Returns:
         callable: The subsolver.
@@ -108,12 +108,11 @@ def get_subsolver(solver, user_options=None, bounds=None):
     valid_bounds = {"lower_bounds", "upper_bounds"}.intersection(args)
 
     bounds_dict = {"lower_bounds": None, "upper_bounds": None}
-    if bounds is not None:
+    if bounds is not None and bounds.has_any:
         for type_ in ["lower", "upper"]:
-            if hasattr(bounds, type_):
-                candidate = getattr(bounds, type_)
-                if candidate is not None and np.isfinite(candidate).any():
-                    bounds_dict[f"{type_}_bounds"] = candidate
+            candidate = getattr(bounds, type_)
+            if candidate is not None and np.isfinite(candidate).any():
+                bounds_dict[f"{type_}_bounds"] = candidate
 
     for name, value in bounds_dict.items():
         if name not in valid_bounds and value is not None:

--- a/src/estimagic/optimization/tranquilo/tranquilo.py
+++ b/src/estimagic/optimization/tranquilo/tranquilo.py
@@ -158,10 +158,10 @@ def _tranquilo(
         functype=functype,
     )
 
-    _has_bounds = _check_if_there_are_bounds(lower_bounds, upper_bounds)
+    bounds = Bounds(lower=lower_bounds, upper=upper_bounds)
 
     if trustregion_shape is None:
-        trustregion_shape = "sphere" if not _has_bounds else "cube"
+        trustregion_shape = "sphere" if not bounds.has_any else "cube"
 
     if sampler is None:
         sampler = f"optimal_{trustregion_shape}"
@@ -223,7 +223,6 @@ def _tranquilo(
         history=history,
     )
 
-    bounds = Bounds(lower=lower_bounds, upper=upper_bounds)
     sample_points = get_sampler(
         sampler,
         bounds=bounds,
@@ -732,15 +731,6 @@ tranquilo_ls = mark_minimizer(
     is_available=True,
     is_global=False,
 )
-
-
-def _check_if_there_are_bounds(lb, ub):
-    out = False
-    if lb is not None and np.isfinite(lb).any():
-        out = True
-    if ub is not None and np.isfinite(ub).any():
-        out = True
-    return out
 
 
 def _get_search_region(trustregion, search_options):

--- a/src/estimagic/optimization/tranquilo/volume.py
+++ b/src/estimagic/optimization/tranquilo/volume.py
@@ -15,26 +15,28 @@ def get_radius_after_volume_scaling(radius, dim, scaling_factor):
     return out
 
 
-def get_radius_of_sphere_with_volume_of_cube(cube_radius, dim, scaling_factor):
+def get_radius_of_sphere_with_volume_of_cube(cube_radius, dim, scaling_factor=None):
     log_radius = (
         loggamma(dim / 2 + 1) / dim
         - np.log(np.pi) / 2
         + np.log(2)
         + np.log(cube_radius)
-        + np.log(scaling_factor) / dim
     )
+    if scaling_factor is not None:
+        log_radius += np.log(scaling_factor) / dim
     out = np.exp(log_radius)
     return out
 
 
-def get_radius_of_cube_with_volume_of_sphere(sphere_radius, dim, scaling_factor):
+def get_radius_of_cube_with_volume_of_sphere(sphere_radius, dim, scaling_factor=None):
     log_radius = (
-        np.log(scaling_factor) / dim
-        + np.log(np.pi) / 2
+        np.log(np.pi) / 2
         + np.log(sphere_radius)
         - np.log(2)
         - loggamma(dim / 2 + 1) / dim
     )
+    if scaling_factor is not None:
+        log_radius += np.log(scaling_factor) / dim
     out = np.exp(log_radius)
     return out
 

--- a/src/estimagic/optimization/tranquilo/weighting.py
+++ b/src/estimagic/optimization/tranquilo/weighting.py
@@ -6,7 +6,7 @@ def get_sample_weighter(weighter, bounds):
 
     The resulting function takes the following arguments:
     - xs (np.ndarray): A 2d numpy array containing a sample.
-    - trustregion (TrustRegion): The current trustregion.
+    - trustregion (Region): Trustregion. See module region.py.
 
     Args:
         weighter (str)

--- a/src/estimagic/visualization/deviation_plot.py
+++ b/src/estimagic/visualization/deviation_plot.py
@@ -70,7 +70,9 @@ def deviation_plot(
         .reset_index()
     )
     average_deviations = (
-        deviations.groupby(["algorithm", "n_evaluations"]).mean()[outcome].reset_index()
+        deviations.groupby(["algorithm", "n_evaluations"])
+        .mean(numeric_only=True)[outcome]
+        .reset_index()
     )
     fig = px.line(average_deviations, x="n_evaluations", y=outcome, color="algorithm")
 

--- a/src/estimagic/visualization/visualize_tranquilo.py
+++ b/src/estimagic/visualization/visualize_tranquilo.py
@@ -11,7 +11,6 @@ from plotly.subplots import make_subplots
 from estimagic.optimization.optimize_result import OptimizeResult
 from estimagic.optimization.tranquilo.clustering import cluster
 from estimagic.optimization.tranquilo.geometry import log_d_quality_calculator
-from estimagic.optimization.tranquilo.options import Bounds
 from estimagic.optimization.tranquilo.volume import get_radius_after_volume_scaling
 
 
@@ -424,13 +423,11 @@ def _plot_distances_from_center(history, state, fig, col, rows):
 def _get_fekete_criterion(res):
     states = res.algorithm_output["states"][1:]
     history = np.array(res.history["params"])
-    bounds = Bounds(lower=-np.inf, upper=np.inf)
 
     out = [np.nan] + [
         log_d_quality_calculator(
             sample=history[state.model_indices],
             trustregion=state.trustregion,
-            bounds=bounds,
         )
         for state in states
     ]

--- a/tests/optimization/tranquilo/test_acceptance_decision.py
+++ b/tests/optimization/tranquilo/test_acceptance_decision.py
@@ -8,10 +8,8 @@ from estimagic.optimization.tranquilo.acceptance_decision import (
     calculate_rho,
 )
 from estimagic.optimization.tranquilo.new_history import History
-from estimagic.optimization.tranquilo.options import (
-    AcceptanceOptions,
-    Region,
-)
+from estimagic.optimization.tranquilo.options import AcceptanceOptions
+from estimagic.optimization.tranquilo.region import Region
 from estimagic.optimization.tranquilo.solve_subproblem import SubproblemResult
 from numpy.testing import assert_array_equal
 
@@ -42,7 +40,7 @@ def acceptance_options():
 # ======================================================================================
 
 
-trustregion = Region(center=np.zeros(2), radius=2.0, shape="sphere")
+trustregion = Region(center=np.zeros(2), radius=2.0)
 State = namedtuple("State", "x trustregion fval index")
 states = [  # we will parametrize over `states`
     State(np.arange(2.0), trustregion, 0.25, 0),  # better than candidate
@@ -92,7 +90,7 @@ def test_get_acceptance_result():
     candidate_fval = 0
     candidate_index = 0
     rho = 1
-    tr = Region(center=np.zeros(2), radius=2.0, shape="sphere")
+    tr = Region(center=np.zeros(2), radius=2.0)
     old_state = namedtuple("State", "x fval index trustregion")(np.arange(2), 1, 1, tr)
 
     ar_when_accepted = _get_acceptance_result(

--- a/tests/optimization/tranquilo/test_bounds.py
+++ b/tests/optimization/tranquilo/test_bounds.py
@@ -1,0 +1,38 @@
+import numpy as np
+import pytest
+from estimagic.optimization.tranquilo.bounds import Bounds, _any_finite
+
+CASES = [
+    (np.array([1, 2]), np.array([5, 6]), True),
+    (np.array([1, 2]), None, True),
+    (None, np.array([5, 6]), True),
+    (None, None, False),
+    (np.array([np.inf, np.inf]), np.array([np.inf, np.inf]), False),
+    (np.array([-np.inf, -np.inf]), np.array([np.inf, np.inf]), False),
+    (np.array([1, 2]), np.array([np.inf, np.inf]), True),
+]
+
+
+@pytest.mark.parametrize("lb, ub, exp", CASES)
+def test_any_finite_true(lb, ub, exp):
+    out = _any_finite(lb, ub)
+    assert out is exp
+
+
+def test_bounds_none():
+    bounds = Bounds(lower=None, upper=None)
+    assert bounds.has_any is False
+
+
+def test_bounds_inifinite():
+    lb = np.array([np.inf, np.inf])
+    ub = np.array([np.inf, np.inf])
+    bounds = Bounds(lower=lb, upper=ub)
+    assert bounds.has_any is False
+
+
+def test_bounds_finite():
+    lb = np.array([1, 2])
+    ub = np.array([5, 6])
+    bounds = Bounds(lower=lb, upper=ub)
+    assert bounds.has_any is True

--- a/tests/optimization/tranquilo/test_estimate_variance.py
+++ b/tests/optimization/tranquilo/test_estimate_variance.py
@@ -29,7 +29,7 @@ def test_estimate_variance_classic(model_type):
     history.add_evals(idxs.repeat(repetitions), evals)
 
     got = _estimate_variance_classic(
-        trustregion=Region(center=np.array([0.0, 0.0]), radius=1.0, shape="sphere"),
+        trustregion=Region(center=np.array([0.0, 0.0]), radius=1.0),
         history=history,
         model_type=model_type,
         max_distance_factor=1.0,

--- a/tests/optimization/tranquilo/test_filter_points.py
+++ b/tests/optimization/tranquilo/test_filter_points.py
@@ -4,7 +4,7 @@ from estimagic.optimization.tranquilo.filter_points import (
     _scaled_square_features,
     drop_collinear_pounders,
 )
-from estimagic.optimization.tranquilo.options import Region
+from estimagic.optimization.tranquilo.region import Region
 from estimagic.optimization.tranquilo.tranquilo import State
 from estimagic.optimization.tranquilo.tranquilo_history import History
 from numpy.testing import assert_array_almost_equal as aaae
@@ -43,7 +43,7 @@ def basic_case():
     )
     indices = np.arange(len(xs))
 
-    trustregion = Region(radius=radius, center=x_accepted, shape="sphere")
+    trustregion = Region(center=x_accepted, radius=radius)
 
     state = State(
         trustregion=trustregion,
@@ -199,7 +199,7 @@ def test_indices_in_trust_region(basic_case):
     x_accepted = np.array([0.16004745, 0.00572722, 0.01158929])
     radius = 0.0125
 
-    trustregion = Region(center=x_accepted, radius=radius, shape="sphere")
+    trustregion = Region(center=x_accepted, radius=radius)
     history.add_entries(xs, np.zeros(xs.shape[0]))
 
     indices_in_tr = history.get_indices_in_region(trustregion)

--- a/tests/optimization/tranquilo/test_fit_models.py
+++ b/tests/optimization/tranquilo/test_fit_models.py
@@ -1,10 +1,7 @@
 import numpy as np
 import pytest
-import yaml
 from estimagic import first_derivative, second_derivative
-from estimagic.config import TEST_FIXTURES_DIR
-from estimagic.optimization.tranquilo.fit_models import _polynomial_features, get_fitter
-from estimagic.optimization.tranquilo.models import ModelInfo
+from estimagic.optimization.tranquilo.fit_models import _quadratic_features, get_fitter
 from estimagic.optimization.tranquilo.options import Region
 from numpy.testing import assert_array_almost_equal, assert_array_equal
 
@@ -16,13 +13,6 @@ def aaae(x, y, case=None):
         "gradient": 3,
     }
     assert_array_almost_equal(x, y, decimal=tolerance[case])
-
-
-def read_yaml(path):
-    with open(rf"{path}") as file:
-        data = yaml.full_load(file)
-
-    return data
 
 
 # ======================================================================================
@@ -38,7 +28,7 @@ def quadratic_case():
 
     """
     n_params = 4
-    n_samples = 2_000
+    n_samples = 15
 
     # theoretical terms
     linear_terms = 1 + np.arange(n_params)
@@ -52,9 +42,8 @@ def quadratic_case():
     x0 = np.ones(n_params)
 
     # random data
-    x = np.array(
-        [x0 + np.random.uniform(-0.01 * x0, 0.01 * x0) for _ in range(n_samples)]
-    )
+    rng = np.random.default_rng(56789)
+    x = np.array([x0 + rng.uniform(-0.01 * x0, 0.01 * x0) for _ in range(n_samples)])
     y = np.array([func(_x) for _x in list(x)]).reshape(-1, 1)
 
     out = {
@@ -66,112 +55,6 @@ def quadratic_case():
         "square_terms_expected": square_terms,
     }
     return out
-
-
-@pytest.fixture()
-def just_identified_case():
-    """Test scenario with true quadratic function and n + 1 points.
-
-    We return true function, and function evaluations and data on random points.
-
-    """
-    n_params = 4
-    n_samples = n_params + 1
-
-    # theoretical terms
-    linear_terms = 1 + np.arange(n_params)
-    square_terms = np.zeros((n_params, n_params))
-
-    def func(x):
-        y = -10 + linear_terms @ x + 0.5 * x.T @ square_terms @ x
-        return y
-
-    x0 = np.ones(n_params)
-
-    # random data
-    x = np.array(
-        [x0 + np.random.uniform(-0.01 * x0, 0.01 * x0) for _ in range(n_samples)]
-    )
-    y = np.array([func(_x) for _x in list(x)]).reshape(-1, 1)
-
-    out = {
-        "func": func,
-        "x0": x0,
-        "x": x,
-        "y": y,
-        "linear_terms_expected": linear_terms,
-        "square_terms_expected": square_terms,
-    }
-    return out
-
-
-@pytest.fixture()
-def data_fit_pounders():
-    """Test data from Tao Pounders."""
-    test_data = read_yaml(TEST_FIXTURES_DIR / "get_coefficients_residual_model.yaml")
-
-    n_params = 3
-    n_samples = 2 * n_params + 1
-    n_poly_features = n_params * (n_params + 1) // 2
-    _is_just_identified = False
-
-    inputs_dict = {
-        "y": np.array(test_data["f_interpolated"]),
-        "m_mat": np.array(test_data["x_sample_monomial_basis"])[
-            : n_params + 1, : n_params + 1
-        ],
-        "n_mat": np.array(test_data["monomial_basis"])[:n_samples],
-        "z_mat": np.array(test_data["basis_null_space"]),
-        "n_z_mat": np.array(test_data["lower_triangular"])[:, n_params + 1 : n_samples],
-        "n_params": n_params,
-        "n_poly_features": n_poly_features,
-        "_is_just_identified": _is_just_identified,
-    }
-
-    expected = {
-        "linear_terms": np.array(test_data["linear_terms_expected"]),
-        "square_terms": np.array(test_data["square_terms_expected"]),
-    }
-
-    return inputs_dict, expected
-
-
-@pytest.fixture()
-def data_get_feature_matrices_pounders():
-    test_data = read_yaml(
-        TEST_FIXTURES_DIR / "get_interpolation_matrices_residual_model.yaml"
-    )
-
-    n_params = 3
-    n_samples = 2 * n_params + 1
-    n_poly_features = n_params * (n_params + 1) // 2
-    center = np.array(test_data["x_accepted"])
-    radius = test_data["delta"]
-
-    model_indices = np.array([13, 12, 11, 10, 9, 8, 6])
-    history_x = np.array(test_data["history_x"])
-    x = (history_x[model_indices] - center) / radius
-
-    inputs_dict = {
-        "x": x,
-        "model_indices": np.array(test_data["model_indices"]),
-        "n_params": n_params,
-        "n_samples": n_samples,
-        "n_poly_features": n_poly_features,
-    }
-
-    expected = {
-        "m_mat": np.array(test_data["x_sample_monomial_basis_expected"])[
-            : n_params + 1, : n_params + 1
-        ],
-        "n_mat": np.array(test_data["monomial_basis_expected"]),
-        "z_mat": np.array(test_data["basis_null_space_expected"]),
-        "n_z_mat": np.array(test_data["lower_triangular_expected"])[
-            :, n_params + 1 : n_samples
-        ],
-    }
-
-    return inputs_dict, expected
 
 
 # ======================================================================================
@@ -180,7 +63,7 @@ def data_get_feature_matrices_pounders():
 
 
 def test_fit_ols_against_truth(quadratic_case):
-    fit_ols = get_fitter("ols")
+    fit_ols = get_fitter("ols", model_type="quadratic")
     got = fit_ols(
         x=quadratic_case["x"],
         y=quadratic_case["y"],
@@ -192,21 +75,17 @@ def test_fit_ols_against_truth(quadratic_case):
     aaae(got.square_terms.squeeze(), quadratic_case["square_terms_expected"])
 
 
-@pytest.mark.parametrize("scenario", ["just_identified_case", "quadratic_case"])
-def test_fit_powell_against_truth(scenario, request):
-    test_case = request.getfixturevalue(scenario)
-
-    model_info = ModelInfo(has_squares=True, has_interactions=True)
-    fit_pounders = get_fitter("powell", model_info=model_info)
+def test_fit_powell_against_truth_quadratic(quadratic_case):
+    fit_pounders = get_fitter("powell", model_type="quadratic")
     got = fit_pounders(
-        test_case["x"],
-        test_case["y"],
+        quadratic_case["x"],
+        quadratic_case["y"],
         region=Region(center=np.zeros(4), radius=1.0, shape="sphere"),
         old_model=None,
     )
 
-    aaae(got.linear_terms.squeeze(), test_case["linear_terms_expected"])
-    aaae(got.square_terms.squeeze(), test_case["square_terms_expected"])
+    aaae(got.linear_terms.squeeze(), quadratic_case["linear_terms_expected"])
+    aaae(got.square_terms.squeeze(), quadratic_case["square_terms_expected"])
 
 
 @pytest.mark.parametrize("model", ["ols", "ridge"])
@@ -216,7 +95,7 @@ def test_fit_ols_against_gradient(model, quadratic_case):
     else:
         options = None
 
-    fit_ols = get_fitter(model, options)
+    fit_ols = get_fitter(model, options, model_type="quadratic")
     got = fit_ols(
         quadratic_case["x"],
         quadratic_case["y"],
@@ -237,7 +116,7 @@ def test_fit_ols_against_gradient(model, quadratic_case):
     [("ols", None), ("ridge", {"l2_penalty_linear": 0, "l2_penalty_square": 0})],
 )
 def test_fit_ols_against_hessian(model, options, quadratic_case):
-    fit_ols = get_fitter(model, options)
+    fit_ols = get_fitter(model, options, model_type="quadratic")
     got = fit_ols(
         quadratic_case["x"],
         quadratic_case["y"],
@@ -249,18 +128,9 @@ def test_fit_ols_against_hessian(model, options, quadratic_case):
     aaae(hessian["derivative"], hess, case="hessian")
 
 
-@pytest.mark.parametrize("has_squares", [True, False])
-def test_polynomial_features(has_squares):
+def test_quadratic_features():
     x = np.array([[0, 1, 2], [3, 4, 5]])
 
-    expected = {
-        # has_squares: expected value,
-        True: np.array(
-            [[1, 0, 1, 2, 0, 0, 0, 1, 2, 4], [1, 3, 4, 5, 9, 12, 15, 16, 20, 25]]
-        ),
-        False: np.array([[1, 0, 1, 2, 0, 0, 2], [1, 3, 4, 5, 12, 15, 20]]),
-    }
-
-    got = _polynomial_features(x, has_squares=has_squares)
-
-    assert_array_equal(got, expected[has_squares])
+    expected = np.array([[0, 1, 2, 0, 0, 0, 1, 2, 4], [3, 4, 5, 9, 12, 15, 16, 20, 25]])
+    got = _quadratic_features(x)
+    assert_array_equal(got, expected)

--- a/tests/optimization/tranquilo/test_fit_models.py
+++ b/tests/optimization/tranquilo/test_fit_models.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 from estimagic import first_derivative, second_derivative
 from estimagic.optimization.tranquilo.fit_models import _quadratic_features, get_fitter
-from estimagic.optimization.tranquilo.options import Region
+from estimagic.optimization.tranquilo.region import Region
 from numpy.testing import assert_array_almost_equal, assert_array_equal
 
 
@@ -67,7 +67,7 @@ def test_fit_ols_against_truth(quadratic_case):
     got = fit_ols(
         x=quadratic_case["x"],
         y=quadratic_case["y"],
-        region=Region(center=np.zeros(4), radius=1.0, shape="sphere"),
+        region=Region(center=np.zeros(4), radius=1.0),
         old_model=None,
     )
 
@@ -80,7 +80,7 @@ def test_fit_powell_against_truth_quadratic(quadratic_case):
     got = fit_pounders(
         quadratic_case["x"],
         quadratic_case["y"],
-        region=Region(center=np.zeros(4), radius=1.0, shape="sphere"),
+        region=Region(center=np.zeros(4), radius=1.0),
         old_model=None,
     )
 
@@ -99,7 +99,7 @@ def test_fit_ols_against_gradient(model, quadratic_case):
     got = fit_ols(
         quadratic_case["x"],
         quadratic_case["y"],
-        region=Region(center=np.zeros(4), radius=1.0, shape="sphere"),
+        region=Region(center=np.zeros(4), radius=1.0),
         old_model=None,
     )
 
@@ -120,7 +120,7 @@ def test_fit_ols_against_hessian(model, options, quadratic_case):
     got = fit_ols(
         quadratic_case["x"],
         quadratic_case["y"],
-        region=Region(center=np.zeros(4), radius=1.0, shape="sphere"),
+        region=Region(center=np.zeros(4), radius=1.0),
         old_model=None,
     )
     hessian = second_derivative(quadratic_case["func"], quadratic_case["x0"])

--- a/tests/optimization/tranquilo/test_geometry.py
+++ b/tests/optimization/tranquilo/test_geometry.py
@@ -1,13 +1,13 @@
 import numpy as np
 from estimagic.optimization.tranquilo.geometry import get_geometry_checker_pair
-from estimagic.optimization.tranquilo.options import Region
+from estimagic.optimization.tranquilo.region import Region
 from estimagic.optimization.tranquilo.sample_points import get_sampler
 
 
 def test_geometry_checker():
-    rng = np.random.default_rng()
-    sampler = get_sampler("sphere", bounds=None)
-    trustregion = Region(center=np.zeros(2), radius=1, shape="sphere")
+    rng = np.random.default_rng(12345)
+    sampler = get_sampler("sphere")
+    trustregion = Region(center=np.zeros(2), radius=1.0)
 
     x = sampler(trustregion, n_points=10, rng=rng)
     x_scaled = x * 0.5
@@ -16,8 +16,8 @@ def test_geometry_checker():
         "d_optimality", reference_sampler="ball", n_params=2, bounds=None
     )
 
-    x_quality = quality_calculator(x, trustregion, bounds=None)
-    x_scaled_quality = quality_calculator(x_scaled, trustregion, bounds=None)
+    x_quality = quality_calculator(x, trustregion)
+    x_scaled_quality = quality_calculator(x_scaled, trustregion)
 
     cutoff = cutoff_simulator(n_samples=10, rng=rng, n_simulations=1_000)
 
@@ -26,11 +26,11 @@ def test_geometry_checker():
 
 
 def test_geometry_checker_scale_invariance():
-    rng = np.random.default_rng()
-    sampler = get_sampler("sphere", bounds=None)
+    rng = np.random.default_rng(12345)
+    sampler = get_sampler("sphere")
 
-    trustregion = Region(center=np.zeros(2), radius=1, shape="sphere")
-    trustregion_scaled = Region(center=np.ones(2), radius=2, shape="sphere")
+    trustregion = Region(center=np.zeros(2), radius=1.0)
+    trustregion_scaled = Region(center=np.ones(2), radius=2.0)
 
     x = sampler(trustregion, n_points=10, rng=rng)
     x_scaled = 1 + 2 * x
@@ -39,7 +39,7 @@ def test_geometry_checker_scale_invariance():
         "d_optimality", reference_sampler="ball", n_params=2, bounds=None
     )
 
-    x_quality = quality_calculator(x, trustregion, bounds=None)
-    x_scaled_quality = quality_calculator(x_scaled, trustregion_scaled, bounds=None)
+    x_quality = quality_calculator(x, trustregion)
+    x_scaled_quality = quality_calculator(x_scaled, trustregion_scaled)
 
     assert x_quality == x_scaled_quality

--- a/tests/optimization/tranquilo/test_models.py
+++ b/tests/optimization/tranquilo/test_models.py
@@ -1,7 +1,6 @@
 import numpy as np
 import pytest
 from estimagic.optimization.tranquilo.models import (
-    ModelInfo,
     ScalarModel,
     VectorModel,
     _predict_scalar,
@@ -52,44 +51,32 @@ def test_predict_vector():
 
 
 def test_n_free_params_name_quadratic():
-    assert n_free_params(dim=2, info_or_name="quadratic") == 1 + 2 + 3
-    assert n_free_params(dim=3, info_or_name="quadratic") == 1 + 3 + 6
-    assert n_free_params(dim=9, info_or_name="quadratic") == 1 + 9 + 45
-
-
-def test_n_free_params_name_diagonal():
-    assert n_free_params(dim=2, info_or_name="diagonal") == 1 + 2 + 2
-    assert n_free_params(dim=3, info_or_name="diagonal") == 1 + 3 + 3
-    assert n_free_params(dim=9, info_or_name="diagonal") == 1 + 9 + 9
+    assert n_free_params(dim=2, model_type="quadratic") == 1 + 2 + 3
+    assert n_free_params(dim=3, model_type="quadratic") == 1 + 3 + 6
+    assert n_free_params(dim=9, model_type="quadratic") == 1 + 9 + 45
 
 
 def test_n_free_params_name_invalid():
     with pytest.raises(ValueError):
-        assert n_free_params(dim=3, info_or_name="invalid")
+        assert n_free_params(dim=3, model_type="invalid")
 
 
 @pytest.mark.parametrize("dim", [2, 3, 9])
 def test_n_free_params_info_linear(dim):
-    info = ModelInfo(has_squares=False, has_interactions=False)
-    assert n_free_params(dim, info) == 1 + dim
-
-
-@pytest.mark.parametrize("dim", [2, 3, 9])
-def test_n_free_params_info_diagonal(dim):
-    info = ModelInfo(has_squares=True, has_interactions=False)
-    assert n_free_params(dim, info) == 1 + dim + dim
+    assert n_free_params(dim, model_type="linear") == 1 + dim
 
 
 @pytest.mark.parametrize("dim", [2, 3, 9])
 def test_n_free_params_info_quadratic(dim):
-    info = ModelInfo(has_squares=True, has_interactions=True)
-    assert n_free_params(dim, info) == 1 + dim + dim + (dim * (dim - 1) // 2)
+    assert n_free_params(dim, model_type="quadratic") == 1 + dim + n_second_order_terms(
+        dim
+    )
 
 
 def test_n_free_params_invalid():
     model = ScalarModel(intercept=1.0, linear_terms=np.ones(1), square_terms=np.ones(1))
     with pytest.raises(ValueError):
-        n_free_params(dim=1, info_or_name=model)
+        n_free_params(dim=1, model_type=model)
 
 
 def test_n_second_order_terms():
@@ -100,11 +87,9 @@ def test_n_interactions():
     assert n_interactions(3) == 3
 
 
-@pytest.mark.parametrize("has_squares", [True, False])
-@pytest.mark.parametrize("has_interactions", [True, False])
-def test_is_second_order_model_info(has_squares, has_interactions):
-    model_info = ModelInfo(has_squares=has_squares, has_interactions=has_interactions)
-    assert is_second_order_model(model_info) == has_squares or has_interactions
+@pytest.mark.parametrize("model_type", ("linear", "quadratic"))
+def test_is_second_order_model_type(model_type):
+    assert is_second_order_model(model_type) == (model_type == "quadratic")
 
 
 def test_is_second_order_model_model():

--- a/tests/optimization/tranquilo/test_models.py
+++ b/tests/optimization/tranquilo/test_models.py
@@ -13,7 +13,7 @@ from estimagic.optimization.tranquilo.models import (
     n_second_order_terms,
     subtract_models,
 )
-from estimagic.optimization.tranquilo.options import Region
+from estimagic.optimization.tranquilo.region import Region
 from numpy.testing import assert_array_almost_equal as aaae
 from numpy.testing import assert_array_equal
 
@@ -112,7 +112,7 @@ def scalar_model():
         intercept=0.5,
         linear_terms=np.array([-0.3, 0.3]),
         square_terms=np.array([[0.8, 0.2], [0.2, 0.7]]),
-        region=Region(center=np.array([0.2, 0.3]), radius=0.6, shape="sphere"),
+        region=Region(center=np.array([0.2, 0.3]), radius=0.6),
     )
     return out
 
@@ -129,14 +129,14 @@ def vector_model():
                 [[0.8, 0.2], [0.2, 0.7]],
             ]
         ),
-        region=Region(center=np.array([0.2, 0.3]), radius=0.6, shape="sphere"),
+        region=Region(center=np.array([0.2, 0.3]), radius=0.6),
     )
     return out
 
 
 def test_move_scalar_model(scalar_model):
     old_region = scalar_model.region
-    new_region = Region(center=np.array([-0.1, 0.1]), radius=0.45, shape="sphere")
+    new_region = Region(center=np.array([-0.1, 0.1]), radius=0.45)
 
     old_model = scalar_model
     x_unscaled = np.array([[0.5, 0.5]])
@@ -156,7 +156,7 @@ def test_move_scalar_model(scalar_model):
 
 def test_move_vector_model(vector_model):
     old_region = vector_model.region
-    new_region = Region(center=np.array([-0.1, 0.1]), radius=0.45, shape="sphere")
+    new_region = Region(center=np.array([-0.1, 0.1]), radius=0.45)
 
     old_model = vector_model
 

--- a/tests/optimization/tranquilo/test_region.py
+++ b/tests/optimization/tranquilo/test_region.py
@@ -5,6 +5,7 @@ from estimagic.optimization.tranquilo.region import (
     Region,
     _any_bounds_binding,
     _get_cube_bounds,
+    _get_cube_center,
     _map_from_unit_cube,
     _map_from_unit_sphere,
     _map_to_unit_cube,
@@ -66,6 +67,12 @@ def test_get_cube_bounds_updated_upper_bounds():
     out = _get_cube_bounds(center=np.zeros(2), radius=1, bounds=bounds)
     assert_array_equal(out.lower, -np.ones(2))
     assert_array_equal(out.upper, 0.5 * np.ones(2))
+
+
+def test_get_cube_center():
+    bounds = Bounds(lower=np.array([0, 0.5]), upper=np.array([1, 10]))
+    out = _get_cube_center(bounds)
+    assert_array_equal(out, np.array([0.5, 5.25]))
 
 
 def test_region_non_binding_bounds():

--- a/tests/optimization/tranquilo/test_region.py
+++ b/tests/optimization/tranquilo/test_region.py
@@ -1,0 +1,90 @@
+import numpy as np
+import pytest
+from estimagic.optimization.tranquilo.bounds import Bounds
+from estimagic.optimization.tranquilo.region import (
+    Region,
+    _any_bounds_binding,
+    _get_cube_bounds,
+    _map_from_unit_cube,
+    _map_from_unit_sphere,
+    _map_to_unit_cube,
+    _map_to_unit_sphere,
+)
+from numpy.testing import assert_array_equal
+
+
+def test_map_to_unit_sphere():
+    got = _map_to_unit_sphere(np.ones(2), center=2 * np.ones(1), radius=2)
+    assert_array_equal(got, -0.5 * np.ones(2))
+
+
+def test_map_to_unit_cube():
+    bounds = Bounds(lower=np.zeros(2), upper=2 * np.ones(2))
+    got = _map_to_unit_cube(np.ones(2), cube_bounds=bounds)
+    assert_array_equal(got, np.zeros(2))
+
+
+def test_map_from_unit_sphere():
+    got = _map_from_unit_sphere(-0.5 * np.ones(2), center=2 * np.ones(1), radius=2)
+    assert_array_equal(got, np.ones(2))
+
+
+def test_map_from_unit_cube():
+    bounds = Bounds(lower=np.zeros(2), upper=2 * np.ones(2))
+    got = _map_from_unit_cube(np.zeros(2), cube_bounds=bounds)
+    assert_array_equal(got, np.ones(2))
+
+
+def test_any_bounds_binding_true():
+    bounds = Bounds(lower=-np.ones(2), upper=np.ones(2))
+    out = _any_bounds_binding(bounds, center=np.zeros(2), radius=2)
+    assert out
+
+
+def test_any_bounds_binding_false():
+    bounds = Bounds(lower=-np.ones(2), upper=np.ones(2))
+    out = _any_bounds_binding(bounds, center=np.zeros(2), radius=0.5)
+    assert not out
+
+
+def test_get_cube_bounds():
+    bounds = Bounds(lower=-np.ones(2), upper=np.ones(2))
+    out = _get_cube_bounds(center=np.zeros(2), radius=1, bounds=bounds)
+    assert_array_equal(out.lower, bounds.lower)
+    assert_array_equal(out.upper, bounds.upper)
+
+
+def test_get_cube_bounds_no_bounds():
+    bounds = Bounds(lower=None, upper=None)
+    out = _get_cube_bounds(center=np.zeros(2), radius=1, bounds=bounds)
+    assert_array_equal(out.lower, -np.ones(2))
+    assert_array_equal(out.upper, np.ones(2))
+
+
+def test_get_cube_bounds_updated_upper_bounds():
+    bounds = Bounds(lower=-2 * np.ones(2), upper=0.5 * np.ones(2))
+    out = _get_cube_bounds(center=np.zeros(2), radius=1, bounds=bounds)
+    assert_array_equal(out.lower, -np.ones(2))
+    assert_array_equal(out.upper, 0.5 * np.ones(2))
+
+
+def test_region_non_binding_bounds():
+    region = Region(center=np.zeros(2), radius=1)
+    assert region.shape == "sphere"
+    assert region.radius == 1
+    assert region.bounds is None
+    with pytest.raises(AttributeError):
+        region.cube_bounds
+    with pytest.raises(AttributeError):
+        region.cube_center
+
+
+def test_region_binding_bounds():
+    bounds = Bounds(lower=-np.ones(2), upper=0.5 * np.ones(2))
+    region = Region(center=np.zeros(2), radius=1, bounds=bounds)
+    assert region.shape == "cube"
+    assert region.radius == 1
+    assert region.bounds is bounds
+    # shrinkage because cube radius is smaller than (spherical) radius
+    assert np.all(bounds.lower - region.cube_bounds.lower < 0)
+    assert_array_equal(region.cube_bounds.upper, bounds.upper)

--- a/tests/optimization/tranquilo/test_rho_noise.py
+++ b/tests/optimization/tranquilo/test_rho_noise.py
@@ -2,7 +2,6 @@ import numpy as np
 import pytest
 from estimagic.optimization.tranquilo.aggregate_models import get_aggregator
 from estimagic.optimization.tranquilo.fit_models import get_fitter
-from estimagic.optimization.tranquilo.models import ModelInfo
 from estimagic.optimization.tranquilo.options import Region
 from estimagic.optimization.tranquilo.rho_noise import simulate_rho_noise
 from estimagic.optimization.tranquilo.solve_subproblem import get_subsolver
@@ -10,7 +9,7 @@ from numpy.testing import assert_array_almost_equal as aaae
 
 
 @pytest.mark.parametrize("functype", ["scalar", "least_squares"])
-def test_convergence_to_one_if_nois_is_tiny(functype):
+def test_convergence_to_one_if_noise_is_tiny(functype):
     """Test simulate_rho_noise.
 
     For the test, the "true" model is a standard sphere function.
@@ -31,27 +30,27 @@ def test_convergence_to_one_if_nois_is_tiny(functype):
 
     if functype == "least_squares":
         fvecs = xs.copy()
-        model_info = ModelInfo(False, False)
+        model_type = "linear"
         model_aggregator = get_aggregator(
             aggregator="least_squares_linear",
             functype="least_squares",
-            model_info=model_info,
+            model_type=model_type,
         )
         n_residuals = 2
     else:
         fvecs = (xs**2).sum(axis=1).reshape(-1, 1)
-        model_info = ModelInfo(True, True)
+        model_type = "quadratic"
         model_aggregator = get_aggregator(
             aggregator="identity",
             functype="scalar",
-            model_info=model_info,
+            model_type=model_type,
         )
         n_residuals = 1
 
     noise_cov = np.eye(n_residuals) * 1e-12
 
     trustregion = Region(center=np.ones(2) * 0.5, radius=1, shape="sphere")
-    model_fitter = get_fitter(fitter="ols", model_info=model_info)
+    model_fitter = get_fitter(fitter="ols", model_type=model_type)
 
     vector_model = model_fitter(
         xs, fvecs, weights=None, region=trustregion, old_model=None

--- a/tests/optimization/tranquilo/test_rho_noise.py
+++ b/tests/optimization/tranquilo/test_rho_noise.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 from estimagic.optimization.tranquilo.aggregate_models import get_aggregator
 from estimagic.optimization.tranquilo.fit_models import get_fitter
-from estimagic.optimization.tranquilo.options import Region
+from estimagic.optimization.tranquilo.region import Region
 from estimagic.optimization.tranquilo.rho_noise import simulate_rho_noise
 from estimagic.optimization.tranquilo.solve_subproblem import get_subsolver
 from numpy.testing import assert_array_almost_equal as aaae
@@ -49,7 +49,7 @@ def test_convergence_to_one_if_noise_is_tiny(functype):
 
     noise_cov = np.eye(n_residuals) * 1e-12
 
-    trustregion = Region(center=np.ones(2) * 0.5, radius=1, shape="sphere")
+    trustregion = Region(center=np.ones(2) * 0.5, radius=1.0)
     model_fitter = get_fitter(fitter="ols", model_type=model_type)
 
     vector_model = model_fitter(

--- a/tests/optimization/tranquilo/test_tranquilo.py
+++ b/tests/optimization/tranquilo/test_tranquilo.py
@@ -64,7 +64,7 @@ def test_internal_tranquilo_scalar_sphere_defaults(
 ):
     res = tranquilo(
         criterion=lambda x: x @ x,
-        x=np.arange(4, dtype=np.float64),
+        x=np.arange(4),
         sample_filter=sample_filter,
         fitter=fitter,
         surrogate_model=surrogate_model,
@@ -104,7 +104,7 @@ def test_internal_tranquilo_scalar_sphere_imprecise_defaults(
 ):
     res = tranquilo(
         criterion=lambda x: x @ x,
-        x=np.arange(4, dtype=np.float64),
+        x=np.arange(4),
         sample_filter=sample_filter,
         fitter=fitter,
         surrogate_model=surrogate_model,
@@ -121,7 +121,7 @@ def test_internal_tranquilo_scalar_sphere_imprecise_defaults(
 def test_external_tranquilo_scalar_sphere_defaults():
     res = minimize(
         criterion=lambda x: x @ x,
-        params=np.arange(4, dtype=np.float64),
+        params=np.arange(4),
         algorithm="tranquilo",
     )
 
@@ -160,7 +160,7 @@ def test_internal_tranquilo_ls_sphere_defaults(
 ):
     res = tranquilo_ls(
         criterion=lambda x: x,
-        x=np.arange(5, dtype=np.float64),
+        x=np.arange(5),
         sample_filter=sample_filter,
         fitter=fitter,
         surrogate_model=surrogate_model,
@@ -177,7 +177,7 @@ def test_internal_tranquilo_ls_sphere_defaults(
 def test_external_tranquilo_ls_sphere_defaults():
     res = minimize(
         criterion=lambda x: x,
-        params=np.arange(5, dtype=np.float64),
+        params=np.arange(5),
         algorithm="tranquilo_ls",
     )
 
@@ -289,7 +289,7 @@ def test_tranquilo_with_noise_handling_and_deterministic_function(algo):
         algo_options={"noisy": True},
     )
 
-    aaae(res.params, np.zeros(5), decimal=4)
+    aaae(res.params, np.zeros(5), decimal=3)
 
 
 @pytest.mark.slow()

--- a/tests/optimization/tranquilo/test_tranquilo.py
+++ b/tests/optimization/tranquilo/test_tranquilo.py
@@ -3,7 +3,6 @@ import itertools
 import numpy as np
 import pytest
 from estimagic.optimization.optimize import minimize
-from estimagic.optimization.tranquilo.models import ModelInfo
 from estimagic.optimization.tranquilo.tranquilo import (
     _process_sample_size,
     _process_surrogate_model,
@@ -192,41 +191,29 @@ def test_external_tranquilo_ls_sphere_defaults():
 
 def test_process_surrogate_model_none_scalar():
     got = _process_surrogate_model(None, functype="scalar")
-    assert got.has_interactions is True
-    assert got.has_squares is True
+    assert got == "quadratic"
 
 
 @pytest.mark.parametrize("functype", ["least_squares", "likelihood"])
 def test_process_surrogate_model_none_not_scalar(functype):
     got = _process_surrogate_model(None, functype=functype)
-    assert got.has_interactions is False
-    assert got.has_squares is False
+    assert got == "linear"
 
 
-@pytest.mark.parametrize("has_interactions", [True, False])
-@pytest.mark.parametrize("has_squares", [True, False])
-def test_process_surrogate_model_info(has_interactions, has_squares):
-    model_info = ModelInfo(has_squares=has_squares, has_interactions=has_interactions)
-    got = _process_surrogate_model(model_info, functype="whatever")
-    assert got == model_info
+@pytest.mark.parametrize("model_type", ("linear", "quadratic"))
+def test_process_surrogate_model_info(model_type):
+    got = _process_surrogate_model(model_type, functype="whatever")
+    assert got == model_type
 
 
 def test_process_surrogate_model_str_linear():
     got = _process_surrogate_model("linear", functype="scalar")
-    assert got.has_interactions is False
-    assert got.has_squares is False
-
-
-def test_process_surrogate_model_str_diagonal():
-    got = _process_surrogate_model("diagonal", functype="least_squares")
-    assert got.has_interactions is False
-    assert got.has_squares is True
+    assert got == "linear"
 
 
 def test_process_surrogate_model_str_quadratic():
     got = _process_surrogate_model("quadratic", functype="likelihood")
-    assert got.has_interactions is True
-    assert got.has_squares is True
+    assert got == "quadratic"
 
 
 def test_process_surrogate_model_str_invalid():
@@ -241,15 +228,13 @@ def test_process_surrogate_model_invalid(functype):
         _process_surrogate_model(surrogate_model, functype=functype)
 
 
-@pytest.mark.parametrize("has_interactions", [True, False])
-@pytest.mark.parametrize("has_squares", [True, False])
-def test_process_sample_size_none_linear(has_interactions, has_squares):
-    model_info = ModelInfo(has_interactions=has_interactions, has_squares=has_squares)
+@pytest.mark.parametrize("model_type", ("linear", "quadratic"))
+def test_process_sample_size_none_linear(model_type):
     x = np.ones((3, 2))
     got = _process_sample_size(
-        None, model_info=model_info, x=x, sample_size_factor=None
+        None, model_type=model_type, x=x, sample_size_factor=None
     )
-    if has_interactions or has_squares:
+    if model_type == "quadratic":
         assert got == 7
     else:
         assert got == 4

--- a/tests/optimization/tranquilo/test_tranquilo.py
+++ b/tests/optimization/tranquilo/test_tranquilo.py
@@ -64,7 +64,7 @@ def test_internal_tranquilo_scalar_sphere_defaults(
 ):
     res = tranquilo(
         criterion=lambda x: x @ x,
-        x=np.arange(4),
+        x=np.arange(4, dtype=np.float64),
         sample_filter=sample_filter,
         fitter=fitter,
         surrogate_model=surrogate_model,
@@ -104,7 +104,7 @@ def test_internal_tranquilo_scalar_sphere_imprecise_defaults(
 ):
     res = tranquilo(
         criterion=lambda x: x @ x,
-        x=np.arange(4),
+        x=np.arange(4, dtype=np.float64),
         sample_filter=sample_filter,
         fitter=fitter,
         surrogate_model=surrogate_model,
@@ -121,7 +121,7 @@ def test_internal_tranquilo_scalar_sphere_imprecise_defaults(
 def test_external_tranquilo_scalar_sphere_defaults():
     res = minimize(
         criterion=lambda x: x @ x,
-        params=np.arange(4),
+        params=np.arange(4, dtype=np.float64),
         algorithm="tranquilo",
     )
 
@@ -160,7 +160,7 @@ def test_internal_tranquilo_ls_sphere_defaults(
 ):
     res = tranquilo_ls(
         criterion=lambda x: x,
-        x=np.arange(5),
+        x=np.arange(5, dtype=np.float64),
         sample_filter=sample_filter,
         fitter=fitter,
         surrogate_model=surrogate_model,
@@ -177,7 +177,7 @@ def test_internal_tranquilo_ls_sphere_defaults(
 def test_external_tranquilo_ls_sphere_defaults():
     res = minimize(
         criterion=lambda x: x,
-        params=np.arange(5),
+        params=np.arange(5, dtype=np.float64),
         algorithm="tranquilo_ls",
     )
 

--- a/tests/optimization/tranquilo/test_volume.py
+++ b/tests/optimization/tranquilo/test_volume.py
@@ -44,6 +44,18 @@ def test_get_radius_of_cube_with_volume_of_sphere(dim):
     assert np.allclose(got, expected)
 
 
+def test_get_radius_of_sphere_with_volume_of_cube_no_scaling():
+    v1 = get_radius_of_sphere_with_volume_of_cube(2.0, 2, None)
+    v2 = get_radius_of_sphere_with_volume_of_cube(2.0, 2, 1.0)
+    assert v1 == v2
+
+
+def test_get_radius_of_cube_with_volume_of_sphere_no_scaling():
+    v1 = get_radius_of_cube_with_volume_of_sphere(2.0, 2, None)
+    v2 = get_radius_of_cube_with_volume_of_sphere(2.0, 2, 1.0)
+    assert v1 == v2
+
+
 @pytest.mark.parametrize("dim", dims)
 def test_radius_after_volume_rescaling_scaling_factor_sphere(dim):
     radius = 0.6


### PR DESCRIPTION
In this PR, we clean up certain components of tranquilo:

1. We create a new module `bounds.py` for the `Bounds` dataclass.
1. We create a new module `region.py` for the `Region` dataclass
    1. The region class is now aware of its shape, which is a sphere if bounds aren't binding and a cube otherwise
    1. The region class now provides methods `map_to_unit` and `map_from_unit` for transitioning between the unit space used in points sampling, fitting, and solving the subproblem, and the regular trustregion space.
1. The sampling code now adaptively samples from the correct shape using the new shape information of the trustregion.
1. We replace the class `ModelInfo` with the string `model_type` which can only be either `linear` or `quadratic`.