### PR TITLE
adjust `update_envs` to make sure that created files have LF line endings

### DIFF
--- a/.envs/update_envs.py
+++ b/.envs/update_envs.py
@@ -42,9 +42,10 @@ def main():
     # write environments
     for name, env in zip(["linux", "others"], [test_env_linux, test_env_others]):
         # Specify newline to avoid wrong line endings on Windows.
-        # See: https://stackoverflow.com/a/23434608
-        with Path(f".envs/testenv-{name}.yml").open("w", newline="\n") as file:
-            file.write("\n".join(env) + "\n")
+        # See: https://stackoverflow.com/a/69869641
+        Path(f".envs/testenv-{name}.yml").write_text(
+            "\n".join(env) + "\n", newline="\n"
+        )
 
 
 if __name__ == "__main__":

--- a/.envs/update_envs.py
+++ b/.envs/update_envs.py
@@ -41,10 +41,10 @@ def main():
 
     # write environments
     for name, env in zip(["linux", "others"], [test_env_linux, test_env_others]):
-        # Open file in binary mode to avoid wrong line endings on Windows.
-        # See: https://stackoverflow.com/a/9184137
-        with Path(f".envs/testenv-{name}.yml").open("wb") as file:
-            file.write(bytes("\n".join(env) + "\n", "UTF-8"))
+        # Specify newline to avoid wrong line endings on Windows.
+        # See: https://stackoverflow.com/a/23434608
+        with Path(f".envs/testenv-{name}.yml").open("w", newline="\n") as file:
+            file.write("\n".join(env) + "\n")
 
 
 if __name__ == "__main__":

--- a/.envs/update_envs.py
+++ b/.envs/update_envs.py
@@ -41,6 +41,8 @@ def main():
 
     # write environments
     for name, env in zip(["linux", "others"], [test_env_linux, test_env_others]):
+        # Open file in binary mode to avoid wrong line endings on Windows.
+        # See: https://stackoverflow.com/a/9184137
         with Path(f".envs/testenv-{name}.yml").open("wb") as file:
             file.write(bytes("\n".join(env) + "\n", "UTF-8"))
 

--- a/.envs/update_envs.py
+++ b/.envs/update_envs.py
@@ -41,7 +41,8 @@ def main():
 
     # write environments
     for name, env in zip(["linux", "others"], [test_env_linux, test_env_others]):
-        Path(f".envs/testenv-{name}.yml").write_text("\n".join(env) + "\n")
+        with Path(f".envs/testenv-{name}.yml").open("wb") as file:
+            file.write(bytes("\n".join(env) + "\n", "UTF-8"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- On Windows, the environment files created by `update_envs` have CRLF line endings.
- In particular, this leads to problems with the `mixed-line-ending` hook.


- This PR makes sure that LF line endings are used by opening the file in binary mode. 
- I am of course open for other solutions.