### PR TITLE
Pass bootstrap_kwargs to bootstrap call in get_moments_cov

### DIFF
--- a/src/estimagic/estimation/msm_weighting.py
+++ b/src/estimagic/estimation/msm_weighting.py
@@ -58,7 +58,9 @@ def get_moments_cov(
         )  # xxxx won't be necessary soon!
         return out
 
-    cov_arr = bootstrap(data=data, outcome=func, outcome_kwargs=moment_kwargs).cov()
+    cov_arr = bootstrap(
+        data=data, outcome=func, outcome_kwargs=moment_kwargs, **bootstrap_kwargs
+    ).cov()
 
     if isinstance(cov_arr, pd.DataFrame):
         cov_arr = cov_arr.to_numpy()  # xxxx won't be necessary soon

--- a/tests/estimation/test_msm_weighting.py
+++ b/tests/estimation/test_msm_weighting.py
@@ -85,3 +85,24 @@ def test_get_moments_cov_runs_with_pytrees():
     assert cov.shape == (3, 3)
 
     assert cov[0, 0] > cov[1, 1] > cov[2, 2]
+
+
+def test_get_moments_cov_passes_bootstrap_kwargs_to_bootstrap():
+    rng = get_rng(1234)
+    data = rng.normal(scale=[10, 5, 1], size=(100, 3))
+    data = pd.DataFrame(data=data)
+
+    def calc_moments(data, keys):
+        means = data.mean()
+        means.index = keys
+        return means.to_dict()
+
+    moment_kwargs = {"keys": ["a", "b", "c"]}
+
+    with pytest.raises(ValueError, match="a must be a positive integer unless no"):
+        get_moments_cov(
+            data=data,
+            calculate_moments=calc_moments,
+            moment_kwargs=moment_kwargs,
+            bootstrap_kwargs={"n_draws": -1},
+        )


### PR DESCRIPTION
Fixes #472 and adds a test case.