### PR TITLE
Identity Weighting Matrix

### DIFF
--- a/src/estimagic/estimation/estimate_msm.py
+++ b/src/estimagic/estimation/estimate_msm.py
@@ -149,7 +149,7 @@ def estimate_msm(
     # Check and process inputs
     # ==================================================================================
 
-    if weights not in ["diagonal", "optimal"]:
+    if weights not in ["diagonal", "optimal", "identity"]:
         raise NotImplementedError("Custom weighting matrices are not yet implemented.")
 
     is_optimized = optimize_options is False

--- a/src/estimagic/estimation/msm_weighting.py
+++ b/src/estimagic/estimation/msm_weighting.py
@@ -78,7 +78,7 @@ def get_weighting_matrix(
     Args:
         moments_cov (pandas.DataFrame or numpy.ndarray): Square DataFrame or Array
             with the covariance matrix of the moment conditions for msm estimation.
-        method (str): One of "optimal", "diagonal".
+        method (str): One of "optimal", "diagonal", or "identity".
         empirical_moments (pytree): Pytree containing empirical moments. Used to get
             the tree structure
         clip_value (float): Bound at which diagonal elements of the moments_cov are
@@ -106,6 +106,8 @@ def get_weighting_matrix(
     elif method == "diagonal":
         diagonal_values = 1 / np.clip(np.diagonal(_internal_cov), clip_value, np.inf)
         array_weights = np.diag(diagonal_values)
+    elif method == "identity":
+        array_weights = np.identity(_internal_cov.shape[0])
     else:
         raise ValueError(f"Invalid method: {method}")
 

--- a/tests/estimation/test_msm_weighting.py
+++ b/tests/estimation/test_msm_weighting.py
@@ -22,7 +22,7 @@ def expected_values():
 cov_np = np.diag([1, 2, 3])
 cov_pd = pd.DataFrame(cov_np)
 
-test_cases = itertools.product([cov_np, cov_pd], ["diagonal", "optimal"])
+test_cases = itertools.product([cov_np, cov_pd], ["diagonal", "optimal", "identity"])
 
 
 @pytest.mark.parametrize("moments_cov, method", test_cases)
@@ -38,7 +38,11 @@ def test_get_weighting_matrix(moments_cov, method):
         assert calculated.columns.equals(moments_cov.columns)
         calculated = calculated.to_numpy()
 
-    expected = np.diag(1 / np.array([1, 2, 3]))
+    if method == "identity":
+        expected = np.identity(cov_np.shape[0])
+    else:
+        expected = np.diag(1 / np.array([1, 2, 3]))
+    
     aaae(calculated, expected)
 
 

--- a/tests/estimation/test_msm_weighting.py
+++ b/tests/estimation/test_msm_weighting.py
@@ -42,7 +42,7 @@ def test_get_weighting_matrix(moments_cov, method):
         expected = np.identity(cov_np.shape[0])
     else:
         expected = np.diag(1 / np.array([1, 2, 3]))
-    
+
     aaae(calculated, expected)
 
 


### PR DESCRIPTION
Added the identity weighting matrix to the MSM estimation:
- First change made is to the `get_weighting_matrix()` function to allow for the identity matrix
- Second change permits `"identity"` as a valid option for weights in `estimate_msm()`