### PR TITLE
Fix API section in docs

### DIFF
--- a/docs/rtd_environment.yml
+++ b/docs/rtd_environment.yml
@@ -25,7 +25,7 @@ dependencies:
   - scipy
   - patsy
   - joblib
-  - plotly
+  - plotly<=5.18
   - ipython
   - pip:
       - ../


### PR DESCRIPTION
In this PR, I fix the API section in the documentation.

In particular, I restrict plotly to version 5.18 or lower.

When using 5.19, autodoc returned the following error, which is raised in plotly-code that was newly introduced in version 5.19:

```console
WARNING: autodoc: failed to import function 'convergence_plot' from module 'estimagic'; the following exception was raised:
Traceback (most recent call last):
  File "/home/tim/miniforge3/envs/estimagic-docs/lib/python3.9/site-packages/sphinx/ext/autodoc/importer.py", line 62, in import_module
    return importlib.import_module(modname)
  File "/home/tim/miniforge3/envs/estimagic-docs/lib/python3.9/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 850, in exec_module
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "/home/tim/miniforge3/envs/estimagic-docs/lib/python3.9/site-packages/estimagic/__init__.py", line 2, in <module>
    from estimagic.benchmarking.get_benchmark_problems import get_benchmark_problems
  File "/home/tim/miniforge3/envs/estimagic-docs/lib/python3.9/site-packages/estimagic/benchmarking/get_benchmark_problems.py", line 5, in <module>
    from estimagic.benchmarking.cartis_roberts import CARTIS_ROBERTS_PROBLEMS
  File "/home/tim/miniforge3/envs/estimagic-docs/lib/python3.9/site-packages/estimagic/benchmarking/cartis_roberts.py", line 21, in <module>
    from estimagic.config import IS_NUMBA_INSTALLED
  File "/home/tim/miniforge3/envs/estimagic-docs/lib/python3.9/site-packages/estimagic/config.py", line 3, in <module>
    import plotly.express as px
  File "/home/tim/miniforge3/envs/estimagic-docs/lib/python3.9/site-packages/plotly/express/__init__.py", line 14, in <module>
    from ._imshow import imshow
  File "/home/tim/miniforge3/envs/estimagic-docs/lib/python3.9/site-packages/plotly/express/_imshow.py", line 3, in <module>
    from ._core import apply_default_cascade, init_figure, configure_animation_controls
  File "/home/tim/miniforge3/envs/estimagic-docs/lib/python3.9/site-packages/plotly/express/_core.py", line 20, in <module>
    pandas_2_2_0 = version.parse(pd.__version__) >= version.parse("2.2.0")
  File "/home/tim/miniforge3/envs/estimagic-docs/lib/python3.9/site-packages/packaging/version.py", line 54, in parse
    return Version(version)
  File "/home/tim/miniforge3/envs/estimagic-docs/lib/python3.9/site-packages/packaging/version.py", line 198, in __init__
    match = self._regex.search(version)
TypeError: expected string or bytes-like object
```