### PR TITLE
Fix documentation

### DIFF
--- a/docs/rtd_environment.yml
+++ b/docs/rtd_environment.yml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
   - nodefaults
 dependencies:
-  - python=3.9
+  - python=3.10
   - pip
   - setuptools_scm
   - toml
@@ -25,7 +25,7 @@ dependencies:
   - scipy
   - patsy
   - joblib
-  - plotly<=5.18
+  - plotly
   - ipython
   - pip:
       - ../

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -67,7 +67,6 @@ autodoc_mock_imports = [
     "fides",
     "joblib",
     "nlopt",
-    "pandas",
     "pytest",
     "pygmo",
     "scipy",


### PR DESCRIPTION
In this PR, we fix the API section of the documentation.

### What happened?

In our documentation, we use [mock imports](https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#confval-autodoc_mock_imports). From the sphinx docs:
> This is useful when some external dependencies are not met at build time and break the building process. You may only specify the root package of the dependencies themselves and omit the sub-modules:

However,  _mocked_ modules cannot be used during build time. This was not a problem until a few weeks ago when `plotly` started checking `pandas` version numbers (mocked for our documentation), which requires the execution of `pandas` code --- namely `pandas.__version__` --- during build time. My unawareness of what was actually happening led me to restrict the `plotly` version (see #480).

In #482, I added code to estimagic that also checked the `pandas` version numbers, leading to the same problem as before.

### Fix

Remove `pandas` from the list of mock imports.