### PR TITLE
Implement a few fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,6 @@ infer_latex_dependencies = true
 filterwarnings = [
     "ignore:Using or importing the ABCs from 'collections'",
     "ignore:the imp module is deprecated",
-    "ignore:indexing past lexsort depth may impact performance.",
     "ignore:Method .ptp is deprecated and will be removed in a future version. Use numpy.ptp instead.",
     "ignore:In a future version of pandas all arguments of concat except for the argument 'objs' will be keyword-only",
     "ignore:Please use `MemoizeJac` from the `scipy.optimize` namespace",

--- a/src/estimagic/estimation/estimate_msm.py
+++ b/src/estimagic/estimation/estimate_msm.py
@@ -27,6 +27,7 @@ from estimagic.inference.shared import (
     transform_free_cov_to_cov,
     transform_free_values_to_params_tree,
 )
+from estimagic.optimization.optimize_result import OptimizeResult
 from estimagic.optimization.optimize import minimize
 from estimagic.parameters.block_trees import block_tree_to_matrix, matrix_to_block_tree
 from estimagic.parameters.conversion import Converter, get_converter
@@ -328,6 +329,7 @@ def estimate_msm(
         _params=estimates,
         _weights=weights,
         _converter=converter,
+        _optimize_result=opt_res,
         _internal_weights=internal_weights,
         _internal_moments_cov=internal_moments_cov,
         _internal_jacobian=int_jac,
@@ -463,6 +465,7 @@ class MomentsResult:
     _internal_jacobian: np.ndarray
     _empirical_moments: Any
     _has_constraints: bool
+    _optimize_result: Union[OptimizeResult, None] = None
     _jacobian: Any = None
     _no_jacobian_reason: Union[str, None] = None
     _cache: Dict = field(default_factory=dict)
@@ -503,6 +506,10 @@ class MomentsResult:
     @property
     def params(self):
         return self._params
+
+    @property
+    def optimize_result(self):
+        return self._optimize_result
 
     @property
     def weights(self):

--- a/src/estimagic/visualization/estimation_table.py
+++ b/src/estimagic/visualization/estimation_table.py
@@ -13,6 +13,7 @@ suppress_performance_warnings = np.testing.suppress_warnings()
 suppress_performance_warnings.filter(category=pd.errors.PerformanceWarning)
 
 
+@suppress_performance_warnings
 def estimation_table(
     models,
     *,

--- a/src/estimagic/visualization/estimation_table.py
+++ b/src/estimagic/visualization/estimation_table.py
@@ -13,7 +13,6 @@ suppress_performance_warnings = np.testing.suppress_warnings()
 suppress_performance_warnings.filter(category=pd.errors.PerformanceWarning)
 
 
-@suppress_performance_warnings
 def estimation_table(
     models,
     *,
@@ -229,6 +228,7 @@ def estimation_table(
         return_type.write_text(out)
 
 
+@suppress_performance_warnings
 def render_latex(
     body,
     footer,

--- a/src/estimagic/visualization/estimation_table.py
+++ b/src/estimagic/visualization/estimation_table.py
@@ -182,7 +182,7 @@ def estimation_table(
     if return_type == "render_inputs":
         out = render_inputs
     elif str(return_type).endswith("tex"):
-        out = render_latex(
+        out = _render_latex(
             **render_inputs,
             show_footer=show_footer,
             append_notes=append_notes,
@@ -281,6 +281,39 @@ def render_latex(
         latex_str (str): The resulting string with Latex tabular code.
 
     """
+    return _render_latex(
+        body=body,
+        footer=footer,
+        render_options=render_options,
+        show_footer=show_footer,
+        append_notes=append_notes,
+        notes_label=notes_label,
+        significance_levels=significance_levels,
+        custom_notes=custom_notes,
+        siunitx_warning=siunitx_warning,
+        show_index_names=show_index_names,
+        show_col_names=show_col_names,
+        show_col_groups=show_col_groups,
+        escape_special_characters=escape_special_characters,
+    )
+
+
+def _render_latex(
+    body,
+    footer,
+    render_options=None,
+    show_footer=True,
+    append_notes=True,
+    notes_label="Note:",
+    significance_levels=(0.1, 0.05, 0.01),
+    custom_notes=None,
+    siunitx_warning=True,
+    show_index_names=False,
+    show_col_names=True,
+    show_col_groups=True,
+    escape_special_characters=True,
+):
+    """See docstring of render_latex for more information."""
     if not pd.__version__ >= "1.4.0":
         raise ValueError(
             r"""render_latex or estimation_table with return_type="latex" requires

--- a/tests/estimation/test_estimate_msm.py
+++ b/tests/estimation/test_estimate_msm.py
@@ -5,6 +5,7 @@ import itertools
 import numpy as np
 import pandas as pd
 import pytest
+from estimagic.optimization.optimize_result import OptimizeResult
 from estimagic.estimation.estimate_msm import estimate_msm
 from estimagic.shared.check_option_dicts import (
     check_numdiff_options,
@@ -63,6 +64,9 @@ def test_estimate_msm(simulate_moments, moments_cov, optimize_options):
 
     # check that minimization works
     aaae(calculated.params, expected_params)
+
+    # assert that optimization result exists and is of correct type
+    assert isinstance(calculated.optimize_result, OptimizeResult)
 
     # check that cov works
     calculated_cov = calculated.cov()

--- a/tests/visualization/test_estimation_table.py
+++ b/tests/visualization/test_estimation_table.py
@@ -136,6 +136,7 @@ PARAMETRIZATION = [("latex", render_latex, models) for models in MODELS]
 PARAMETRIZATION += [("html", render_html, models) for models in MODELS]
 
 
+@pytest.mark.filterwarnings("error:indexing past lexsort depth may impact performance.")
 @pytest.mark.parametrize("return_type, render_func,models", PARAMETRIZATION)
 def test_one_and_stage_rendering_are_equal(return_type, render_func, models):
     first_stage = estimation_table(

--- a/tests/visualization/test_estimation_table.py
+++ b/tests/visualization/test_estimation_table.py
@@ -136,7 +136,6 @@ PARAMETRIZATION = [("latex", render_latex, models) for models in MODELS]
 PARAMETRIZATION += [("html", render_html, models) for models in MODELS]
 
 
-@pytest.mark.filterwarnings("error:indexing past lexsort depth may impact performance.")
 @pytest.mark.parametrize("return_type, render_func,models", PARAMETRIZATION)
 def test_one_and_stage_rendering_are_equal(return_type, render_func, models):
     first_stage = estimation_table(


### PR DESCRIPTION
In this PR, we implement a few fixes.

1. Suppress pandas PerformanceWarnings (before this, we suppressed warnings that occurred in the function `estimation_table`, but these warnings were raised in the function `render_latex`, where we did not suppress them; for reference, see #379 )
2. Add full optimization result to the return object of the `estimate_msm` function. This closes #491.  